### PR TITLE
Fix misconfigurations in MI config catalog doc

### DIFF
--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -2702,7 +2702,7 @@ allowed_headers = "Authorization"</code></pre>
                 <div class="doc-wrapper">
                     <div class="mb-config">
                         <div class="config-wrap">
-                            <code>[[management_api.cors]]</code>
+                            <code>[management_api.cors]</code>
                             <span class="badge-required">Required</span>
                             <p>
                                 This configuration header is required for configuring CORs for the Management API of the Micro Integrator. Read more about <a href='../../install-and-setup/setup/mi-setup/security/securing_management_api'>securing the Management API</a>.
@@ -2744,7 +2744,7 @@ allowed_headers = "Authorization"</code></pre>
                                             <span class="param-default-value">Default: <code>*</code></span>
                                         </div>
                                         <div class="param-possible">
-                                            <span class="param-possible-values">Possible Values: <code>&quot;true&quot; or &quot;false&quot;</code></span>
+                                            <span class="param-possible-values">Possible Values: <code>any string</code></span>
                                         </div>
                                     </div>
                                     <div class="param-description">
@@ -3726,11 +3726,11 @@ listener.verify_client = "require"
 listener.ssl_profile.file_path = "conf/sslprofiles/listenerprofiles.xml"
 listener.ssl_profile.read_interval = "1h"
 listener.preferred_ciphers = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
-listener.keystore.file_name ="$ref{keystore.tls.file_name}"
+listener.keystore.location ="$ref{keystore.tls.file_name}"
 listener.keystore.type = "$ref{keystore.tls.type}"
 listener.keystore.password = "$ref{keystore.tls.password}"
 listener.keystore.key_password = "$ref{keystore.tls.key_password}"
-listener.truststore.file_name = "$ref{truststore.file_name}"
+listener.truststore.location = "$ref{truststore.file_name}"
 listener.truststore.type = "$ref{truststore.type}"
 listener.truststore.password = "$ref{truststore.password}"
 sender.warn_on_http_500 = "*"
@@ -3738,11 +3738,11 @@ sender.proxy_host = "$ref{server.hostname}"
 sender.proxy_port = 3128
 sender.non_proxy_hosts = ["$ref{server.hostname}"]
 sender.hostname_verifier = "AllowAll"
-sender.keystore.file_name ="$ref{keystore.tls.file_name}"
+sender.keystore.location ="$ref{keystore.tls.file_name}"
 sender.keystore.type = "$ref{keystore.tls.type}"
 sender.keystore.password = "$ref{keystore.tls.password}"
 sender.keystore.key_password = "$ref{keystore.tls.key_password}"
-sender.truststore.file_name = "$ref{truststore.file_name}"
+sender.truststore.location = "$ref{truststore.file_name}"
 sender.truststore.type = "$ref{truststore.type}"
 sender.truststore.password = "$ref{truststore.password}"
 sender.ssl_profile.file_path = "conf/sslprofiles/senderprofiles.xml"
@@ -4018,7 +4018,7 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>listener.keystore.file_name</code> </span>
+                                  <span class="param-name-wrap"> <code>listener.keystore.location</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
@@ -4102,7 +4102,7 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>listener.truststore.file_name</code> </span>
+                                  <span class="param-name-wrap"> <code>listener.truststore.location</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
@@ -4396,7 +4396,7 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.keystore.file_name</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.keystore.location</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>
@@ -4480,7 +4480,7 @@ force_json_validation = false</code></pre>
                                 </div>
                             </div><div class="param">
                                 <div class="param-name">
-                                  <span class="param-name-wrap"> <code>sender.truststore.file_name</code> </span>
+                                  <span class="param-name-wrap"> <code>sender.truststore.location</code> </span>
                                 </div>
                                 <div class="param-info">
                                     <div>


### PR DESCRIPTION
The following needs to updated in the https://apim.docs.wso2.com/en/latest/reference/config-catalog-mi/#https-transport-non-blocking-mode page,

The HTTP transport keystores (https://apim.docs.wso2.com/en/latest/reference/config-catalog-mi/#https-transport-non-blocking-mode)
listener.keystore.file_name --> listener.keystore.location
sender.keystore.file_name --> sender.keystore.location
listener.truststore.file_name -- > listener.truststore.location
sender.truststore.file_name --> sender.truststore.location

Management API configs (https://apim.docs.wso2.com/en/latest/reference/config-catalog-mi/#management-api-cors)
Need to have only single square bracket for the below property
[[management_api.cors]] --> [management_api.cors]

Possible Values under allowed_origins should be "any string" instead of true or false