### PR TITLE
Remove navigation separation

### DIFF
--- a/en/theme/material/customizations.md
+++ b/en/theme/material/customizations.md
@@ -150,7 +150,7 @@ theme/material/assets/stylesheets/application.*.css
 theme/material/base.html
 ```
 
-5. Copy the the new files back to your `docs-apim` clone from the `mkdocs-material` clone you built at step 3.
+5. Copy the new files back to your `docs-apim` clone from the `mkdocs-material` clone you built at step 3.
 
 ```
 material/assets/javascripts/application.*.js
@@ -158,7 +158,3 @@ material/assets/javascripts/modernizr.*.js
 material/assets/stylesheets/application*
 material/base.html
 ```
-# Customizations done to the top navigation tabs-item.html for navigation seperation
-
-Top navigation seperation is achieved through matching the titles of pages which are on the right.
-If titles needs to be changed in right floted nav links, tabs-item.html has to be changed as well.

--- a/en/theme/material/partials/tabs-item.html
+++ b/en/theme/material/partials/tabs-item.html
@@ -18,7 +18,6 @@
     {% set nav_item = nav_item.children | first %}
     {% include "partials/tabs-item.html" %}
   {% else %}
-    {% if (title != 'Tutorials') and (title != 'Install and Setup') and (title != 'Administer') and (title != 'Reference') %}
       <li class="md-tabs__item">
         {% if nav_item.active %}
           <a href="{{ (nav_item.children | first).url | url }}" title="{{ title }}" class="md-tabs__link md-tabs__link--active">
@@ -30,21 +29,5 @@
           </a>
         {% endif %}
       </li>
-    {% endif %}
-    {% if (title == 'Tutorials') or (title == 'Install and Setup') or (title == 'Administer') or (title == 'Reference') %}
-      <div class="floatRight">
-        <li class="md-tabs__item">
-          {% if nav_item.active %}
-            <a href="{{ (nav_item.children | first).url | url }}" title="{{ title }}" class="md-tabs__link md-tabs__link--active">
-              {{ title }}
-            </a>
-          {% else %}
-            <a href="{{ (nav_item.children | first).url | url }}" title="{{ title }}" class="md-tabs__link">
-              {{ title }}
-            </a>
-          {% endif %}
-        </li>
-      </div>
-    {% endif %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
## Purpose
This PR is to remove the separation done to the top navigation bar. 

This modification, originally present in the APIM documentation, is unnecessary in the MI documentation. Therefore removing it via this PR.