### PR TITLE
[4.2.0] Update message-builders-and-formatters.md

### DIFF
--- a/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
+++ b/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
@@ -59,7 +59,7 @@ If you want to enable message relay, so that messages of a specific content type
 
 ```toml
 [[custom_message_formatters]]
-class = "org.wso2.carbon.relay.BinaryRelayBuilder"
+class = "org.wso2.carbon.relay.ExpandingMessageFormatter"
 content_type = "application/json/badgerfish"
 
 [[custom_message_builders]]


### PR DESCRIPTION
## Purpose
This PR is to fix an error in the `custom_message_formatters` config.

Issue reference: https://github.com/wso2/docs-apim/issues/7556