### PR TITLE
Updating dataservice sample projects related documentation

### DIFF
--- a/en/docs/learn/samples/database-polling.md
+++ b/en/docs/learn/samples/database-polling.md
@@ -58,8 +58,7 @@ The scheduled task runs periodically and injects a dummy payload to the sequence
 1. Open the sample by clicking on the **Database Polling** card.
 2. Give a folder location to save the sample.
 3. Open the `DoctorsDataService` data service artifact and update the RDBMS datasource in it by replacing the `URL`, `Username` and `Password` values with your database credentials.
-4. [Download the `mysql-connector-j-8.0.32.jar`](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.0.32) and add it to the `<PROJECT_NAME>/deployment/libs` folder.
-5. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
+4. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
 
 ## Running the sample
 

--- a/en/docs/learn/samples/rest-data-service.md
+++ b/en/docs/learn/samples/rest-data-service.md
@@ -38,8 +38,7 @@ This sample contains a Data Service called `RESTDataService` that include data s
 1. Open the sample by clicking on the **REST Data Service** card.
 2. Give a folder location to save the sample.
 3. Open the `RESTDataService` data service artifact and update the RDBMS datasource in it by replacing the `URL`, `Username` and `Password` values with your database credentials.
-4. [Download the `mysql-connector-j-8.0.32.jar`](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.0.32) and add it to the `<PROJECT_NAME>/deployment/libs` folder.
-5. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
+4. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
 
 ## Running the sample
 

--- a/en/docs/learn/samples/students-data-service.md
+++ b/en/docs/learn/samples/students-data-service.md
@@ -38,8 +38,7 @@ This sample contains a Data Service called `StudentDataService` that include dat
 1. Open the sample by clicking on the **Students Data Service** card.
 2. Give a folder location to save the sample.
 3. Open the `StudentDataService` data service artifact and update the RDBMS datasource in it by replacing the `URL`, `Username` and `Password` values with your database credentials.
-4. [Download the `mysql-connector-j-8.0.32.jar`](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.0.32) and add it to the `<PROJECT_NAME>/deployment/libs` folder.
-5. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
+4. [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your Micro Integrator.
 
 ## Running the sample
 


### PR DESCRIPTION
This PR removes the instruction to download and add the mysql-connector to the project as the samples were updated to download the relevant dependencies.