### PR TITLE
[4.3.0] Add custom dropdown component

### DIFF
--- a/en/docs/assets/css/mitheme.css
+++ b/en/docs/assets/css/mitheme.css
@@ -183,3 +183,116 @@ header>.md-grid {
         display: none;
     }
 }
+
+/* Custom dropdown specific styles */
+
+.md-header__version-select {
+    overflow: visible;
+    width: 3.5rem;
+    margin-left: 1.5rem;
+}
+
+.md-header__version-select .md-tabs__link.md-tabs__dropdown-link {
+    display: inline-block;
+    padding: .45rem;
+    margin-top: .35rem;
+    border-radius: .1rem;
+}
+
+.md-header__version-select .mb-tabs__dropdown .mb-tabs__dropdown-content,
+.md-header__distribution-select .mb-tabs__dropdown .mb-tabs__dropdown-content {
+    background: #e2e2e2;
+    opacity: 1;
+}
+
+.md-header__version-select .mb-tabs__dropdown .mb-tabs__dropdown-content {
+    top: .6rem;
+}
+.mb-tabs__dropdown {
+    position: relative;
+}
+
+.md-tabs__dropdown-link {
+    display: contents;
+}
+
+.mb-tabs__dropdown.group-select {
+    background-color: #737373;
+}
+.mb-tabs__dropdown .mb-tabs__dropdown-content {
+    position: absolute;
+    left: 0;
+    top: 3.5em;
+    -webkit-transition: all .2s cubic-bezier(.680, 0, .265, 1);
+    transition: all .2s;
+    -webkit-transform: scale(0);
+    transform: scale(0);
+    -webkit-transform-origin: 0 0;
+    transform-origin: top left;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .16), 0 2px 8px 0 rgba(0, 0, 0, .12);
+    background: #fff;
+    font-size: 1.4rem;
+    color: #242424;
+    padding: 0;
+    z-index: 1;
+}
+
+.mb-tabs__dropdown .mb-tabs__dropdown-content .md-tabs__item {
+    padding: 0;
+}
+
+.mb-tabs__dropdown .mb-tabs__dropdown-content li {
+    display: block;
+    width: 100%;
+    opacity: 0;
+    transform: translate(-20px, 0);
+}
+
+.mb-tabs__dropdown.open .mb-tabs__dropdown-content li {
+    display: block;
+    transition: all .4s;
+    opacity: 1;
+    transform: translate(0, 0);
+    height: auto;
+}
+
+.mb-tabs__dropdown ul li a {
+    width: 100%;
+    padding: .5rem;
+    white-space: pre;
+    box-sizing: border-box;
+    display: block;
+    font-size: .7rem;
+    text-transform: capitalize;
+}
+
+.mb-tabs__dropdown ul li a:hover {
+    background: #ebebeb;
+}
+
+.mb-tabs__dropdown.open .mb-tabs__dropdown-content {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    transition-timing-function: cubic-bezier(.680, 0, .265, 1);
+}
+.md-header__version-select .md-tabs__link.md-tabs__dropdown-link {
+    display: inline-block;
+    padding: .45rem;
+    margin-top: .35rem;
+    border-radius: .1rem;
+}
+
+.md-header__version-select .md-tabs__link {
+    color: var(--md-primary-fg-color-header-text-active);
+}
+
+.md-header__version-select .mb-tabs__dropdown .mb-tabs__dropdown-content,
+.md-header__distribution-select .mb-tabs__dropdown .mb-tabs__dropdown-content {
+    background: #e2e2e2;
+    opacity: 1;
+}
+
+.md-header__version-select .mb-tabs__dropdown .mb-tabs__dropdown-content {
+    top: .6rem;
+}
+/* End of custom dropdown specific styles */

--- a/en/docs/assets/css/mitheme.css
+++ b/en/docs/assets/css/mitheme.css
@@ -296,3 +296,8 @@ header>.md-grid {
     top: .6rem;
 }
 /* End of custom dropdown specific styles */
+
+/* The code block below hides the dropdown. Remove it after the next release. */
+.mb-tabs__dropdown{
+    display: none;
+}

--- a/en/docs/assets/css/mitheme.css
+++ b/en/docs/assets/css/mitheme.css
@@ -297,7 +297,3 @@ header>.md-grid {
 }
 /* End of custom dropdown specific styles */
 
-/* The code block below hides the dropdown. Remove it after the next release. */
-.mb-tabs__dropdown{
-    display: none;
-}

--- a/en/docs/assets/js/mitheme.js
+++ b/en/docs/assets/js/mitheme.js
@@ -38,3 +38,152 @@ window.addEventListener("DOMContentLoaded", function() {
         });
     }
 })();
+
+/*
+ * Initialize custom dropdown component
+ */
+var dropdowns = document.getElementsByClassName('md-tabs__dropdown-link');
+var dropdownItems = document.getElementsByClassName('mb-tabs__dropdown-item');
+
+function indexInParent(node) {
+    var children = node.parentNode.childNodes;
+    var num = 0;
+    for (var i=0; i < children.length; i++) {
+         if (children[i]==node) return num;
+         if (children[i].nodeType==1) num++;
+    }
+    return -1;
+}
+
+for (var i = 0; i < dropdowns.length; i++) {
+    var el = dropdowns[i];
+    var openClass = 'open';
+
+    el.onclick = function () {
+        if (this.parentElement.classList) {
+            this.parentElement.classList.toggle(openClass);
+        } else {
+            var classes = this.parentElement.className.split(' ');
+            var existingIndex = classes.indexOf(openClass);
+
+            if (existingIndex >= 0)
+                classes.splice(existingIndex, 1);
+            else
+                classes.push(openClass);
+
+            this.parentElement.className = classes.join(' ');
+        }
+    };
+};
+
+/*
+ * Reading versions
+ */
+var pageHeader = document.getElementById('page-header');
+var docSetLang = pageHeader.getAttribute('data-lang');
+
+(window.location.pathname.split('/')[1] !== docSetLang) ?
+    docSetLang = '' :
+    docSetLang = docSetLang + '/';
+
+var docSetUrl = window.location.origin + '/' + docSetLang;
+var request = new XMLHttpRequest();
+
+request.open('GET', docSetUrl +
+             'versions/assets/versions.json', true);
+
+request.onload = function() {
+  if (request.status >= 200 && request.status < 400) {
+
+      var data = JSON.parse(request.responseText);
+      var dropdown =  document.getElementById('version-select-dropdown');
+      var checkVersionsPage = document.getElementById('current-version-stable');
+
+      /*
+       * Appending versions to the version selector dropdown
+       */
+      if (dropdown){
+          data.list.sort().forEach(function(key, index){
+              var versionData = data.all[key];
+
+              if(versionData) {
+                  var liElem = document.createElement('li');
+                  var docLinkType = data.all[key].doc.split(':')[0];
+                  var target = '_self';
+                  var url = data.all[key].doc;
+
+                  var currentPath= window.location.pathname;
+                     // Find the index of '/en/'
+                  var pathWithoutEn = currentPath.substring(4,currentPath.length);
+                  var pathWithoutVersion = pathWithoutEn.substring(pathWithoutEn.indexOf("/"), pathWithoutEn.length)
+
+                  url = docSetUrl + key+ pathWithoutVersion;
+
+
+                  liElem.className = 'md-tabs__item mb-tabs__dropdown';
+                  liElem.innerHTML =  '<a href="'+ url+'">' + key + '</a>';
+
+                  dropdown.insertBefore(liElem, dropdown.firstChild);
+              }
+          });
+
+          document.getElementById('show-all-versions-link')
+              .setAttribute('href', docSetUrl + 'versions');
+      }
+
+      /*
+       * Appending versions to the version tables in versions page
+       */
+      if (checkVersionsPage){
+          var previousVersions = [];
+
+          Object.keys(data.all).forEach(function(key, index){
+              if ((key !== data.current) && (key !== data['pre-release'])) {
+                  var docLinkType = data.all[key].doc.split(':')[0];
+                  var target = '_self';
+
+                  if ((docLinkType == 'https') || (docLinkType == 'http')) {
+                      target = '_blank'
+                  }
+
+                  previousVersions.push('<tr>' +
+                    '<th>' + key + '</th>' +
+                        '<td>' +
+                            '<a href="' + data.all[key].doc + '" target="' +
+                                target + '">Documentation</a>' +
+                        '</td>' +
+                        '<td>' +
+                            '<a href="' + data.all[key].notes + '" target="' +
+                                target + '">Release Notes</a>' +
+                        '</td>' +
+                    '</tr>');
+              }
+          });
+
+          // Past releases update
+          document.getElementById('previous-versions').innerHTML =
+                  previousVersions.join(' ');
+
+          // Current released version update
+          document.getElementById('current-version-number').innerHTML =
+                  data.current;
+          document.getElementById('current-version-documentation-link')
+                  .setAttribute('href', docSetUrl + data.all[data.current].doc);
+          document.getElementById('current-version-release-notes-link')
+                  .setAttribute('href', docSetUrl + data.all[data.current].notes);
+
+          // Pre-release version update
+          document.getElementById('pre-release-version-documentation-link')
+              .setAttribute('href', docSetUrl + 'next/');
+      }
+
+  } else {
+      console.error("We reached our target server, but it returned an error");
+  }
+};
+
+request.onerror = function() {
+    console.error("There was a connection error of some sort");
+};
+
+request.send();

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -1,0 +1,124 @@
+<!--
+ * Copyright (c) 2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+{% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+{% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header" id="page-header" data-url="{{ url }}" data-lang="{{ config.theme.language }}">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}"
+       class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      {% include ".icons/material/menu" ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name | replace('WSO2', '') }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="md-flex__ellipsis md-header__version-select">
+      <div class="mb-tabs__dropdown version-select">
+        <a class="md-tabs__link md-tabs__dropdown-link" href="#!" data-target="version-select-dropdown">
+          {{ config.extra.site_version }}
+          <i class="fa-solid fa-angle-down"></i>
+        </a>
+        <ul id="version-select-dropdown" class="mb-tabs__dropdown-content" tabindex="0">
+          <!-- Versions will added here dynamically -->
+          <li class="md-tabs__item mb-tabs__dropdown">
+            <a href="#" id="show-all-versions-link">Show all</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    </div>
+    {% if not config.theme.palette is mapping %}
+    <form class="md-header__option" data-md-component="palette">
+      {% for option in config.theme.palette %}
+      {% set scheme = option.scheme | d("default", true) %}
+      <input class="md-option" data-md-color-media="{{ option.media }}"
+             data-md-color-scheme="{{ scheme | replace(' ', '-') }}"
+             data-md-color-primary="{{ option.primary | replace(' ', '-') }}"
+             data-md-color-accent="{{ option.accent | replace(' ', '-') }}" {% if option.toggle %}
+             aria-label="{{ option.toggle.name }}" {% else %} aria-hidden="true" {% endif %} type="radio" name="__palette"
+             id="__palette_{{ loop.index }}">
+      {% if option.toggle %}
+      <label class="md-header__button md-icon" title="{{ option.toggle.name }}"
+             for="__palette_{{ loop.index0 or loop.length }}" hidden>
+        {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+      </label>
+      {% endif %}
+      {% endfor %}
+    </form>
+    {% endif %}
+    {% if config.extra.alternate %}
+    <div class="md-header__option">
+      <div class="md-select">
+        {% set icon = config.theme.icon.alternate or "material/translate" %}
+        <button class="md-header__button md-icon" aria-label="{{ lang.t('select.language') }}">
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </button>
+        <div class="md-select__inner">
+          <ul class="md-select__list">
+            {% for alt in config.extra.alternate %}
+            <li class="md-select__item">
+              <a href="{{ alt.link | url }}" hreflang="{{ alt.lang }}" class="md-select__link">
+                {{ alt.name }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+    <label class="md-header__button md-icon" for="__search">
+      {% include ".icons/material/magnify.svg" %}
+    </label>
+    {% include "partials/search.html" %}
+    {% endif %}
+    {% if config.repo_url %}
+    <div class="md-header__source">
+      {% include "partials/source.html" %}
+    </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+  {% if "navigation.tabs" in features %}
+  {% include "partials/tabs.html" %}
+  {% endif %}
+  {% endif %}
+</header>


### PR DESCRIPTION
## Purpose
This PR is to add the custom dropdown component to fetch and display the doc versions, its functionalities and style adjustments.

---

<img width="70%" alt="dropdown-4 3 0" src="https://github.com/user-attachments/assets/fbd5e256-73ab-4c88-8c96-0ecb93a081e8">

---

- It includes a code block to temporarily hide the dropdown from the UI until the next release. [Added via [864803b](https://github.com/wso2/docs-mi/commit/864803b9e0eb7f7bb015ffdf22f09b7a67e2ac60)] Hence, until it is removed, the dropdown will remain hidden.

- It also includes a fix to maintain the URL path when switching between versions (to remain on the same page when switching the versions).