### PR TITLE
Deploying micro integrator with helm

### DIFF
--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -43,7 +43,7 @@ Follow the steps below to configure how your Micro Integrator deployment should 
 
     - **Update the WSO2 subscription details**
     
-        You can update the user name and password in the following section. If you don't have an active WSO2 subscription, leave these parameters empty.
+        You can update the username and password in the following section. If you don't have an active WSO2 subscription, leave these parameters empty.
     
         ```yaml
         wso2:

--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -9,14 +9,14 @@ Follow the instructions given below to deploy the Micro Integrator on Kubernetes
     !!! Note
         You need an active subscription to use the updated Docker images of the Micro Integrator with your Helm resources. Otherwise, you can use the community version of Docker images, which do not include product updates.
     
--   Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Helm](https://helm.sh/docs/intro/install/), [Dep](https://golang.github.io/dep/docs/installation.html), and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+-   Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Helm](https://helm.sh/docs/intro/install/), and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
     
 -   Set up a [Kubernetes cluster](https://kubernetes.io/docs/setup/#learning-environment).
     
 -   Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/). 
 
     !!! Note
-        Helm resources for WSO2 product deployment patterns are compatible with the [`nginx-0.30.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.30.0) release.
+        Helm resources for WSO2 product deployment patterns are compatible with the ingress-nginx [`controller-v1.11.2`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.2) release.
 
 ## Step 1 - Get the Helm resources
 
@@ -26,22 +26,18 @@ Check out the Helm Resources for the WSO2 Micro Integrator Git repository.
 2.  Clone the Micro Integrator Git repository with Helm resources:
 
     ```bash
-    git clone https://github.com/wso2/kubernetes-mi.git
-    git checkout tags/v4.3.0.0
+    git clone https://github.com/wso2/helm-mi.git
     ```
 
-This creates a local copy of [`wso2/kubernetes-mi`](https://github.com/wso2/kubernetes-mi/), which includes all the Helm Resources for WSO2 Micro Integrator.
+This creates a local copy of [`wso2/helm-mi`](https://github.com/wso2/helm-mi/), which includes all the Helm Resources for WSO2 Micro Integrator.
 
-Let's refer to the root folder of the local copy as `<KUBERNETES_HOME>`.
+Let's refer to the root folder of the local copy as `<HELM_HOME>`.
 
 ## Step 2 - Update the deployment configurations 
 
 Follow the steps given below to configure how your Micro Integrator deployment should be set up.
 
-1.  Open the `values.yaml` file in the `<KUBERNETES_HOME>/helm/micro-integrator` folder of your local copy.
-
-    !!! Info
-        Before you do any changes, go through the [default configurations](https://github.com/wso2/kubernetes-mi/tree/v4.3.0.0/helm/micro-integrator) in this file.
+1.  Open the `values.yaml` file in the `<HELM_HOME>/mi` folder of your local copy.
 
 2.  Use the following guidelines to update the deployment configurations:
 
@@ -63,19 +59,26 @@ Follow the steps given below to configure how your Micro Integrator deployment s
         By default, the `values.yaml` file uses the base Micro Integrator image (which does not include any integrations) to set up the deployment.
 
         ```yaml
-        imageName: "wso2mi"
-        imageTag: "4.3.0"
+        containerRegistry: "docker.wso2.com"
+        wso2:
+            deployment:
+                image: 
+                    repository: "wso2mi"
+                    tag: "4.3.0"
         ```
 
-        When you have a custom Docker image with integrations, uncomment the `dockerRegistry` parameter and the details of your custom image.
+        When you have a custom Docker image with integrations, change the `containerRegistry` parameter and the details of your custom image.
 
         ```yaml
-        dockerRegistry: "<docker_registry>"
-        imageName: "<custom_mi_image>"
-        imageTag: "<custom_image_tag>"
+        containerRegistry: "<docker_registry>"
+        wso2:
+            deployment:
+                image: 
+                    repository: "<custom_mi_repository>"
+                    tag: "<custom_image_tag>"
         ```
 
-    -   You can update [other configurations](https://github.com/wso2/kubernetes-mi/blob/v4.3.0.0/helm/micro-integrator/README.md) as required.
+    -   You can update [other configurations](https://github.com/wso2/helm-mi/blob/main/mi/EXAMPLES.md) as required.
 
 3.  Save the `values.yaml` file.
 
@@ -83,7 +86,7 @@ Follow the steps given below to configure how your Micro Integrator deployment s
 
 Once you have set up your Helm resources locally, follow the instructions given below to set up the deployment.
 
-1.  Open a terminal and navigate to the `<KUBERNETES_HOME>/helm/micro-integrator` folder.
+1.  Open a terminal and navigate to the `<HELM_HOME>/mi` folder.
 2.  Execute the command that is relevant to your Helm version.
 
     !!! Tip
@@ -92,13 +95,13 @@ Once you have set up your Helm resources locally, follow the instructions given 
     -   Using **Helm v2**
         
         ```bash
-        helm install --name <RELEASE_NAME> wso2/micro-integrator --version 4.3.0-0 --namespace <NAMESPACE>
+        helm install --name <RELEASE_NAME> ./ -f values.yaml -n <NAMESPACE>
         ```
 
     -   Using **Helm v3**
         
         ```bash
-        helm install <RELEASE_NAME> wso2/micro-integrator --version 4.3.0-0 --namespace <NAMESPACE> --create-namespace
+        helm install <RELEASE_NAME> ./ -f values.yaml -n <NAMESPACE> --create-namespace
         ```
         
 #### Update configurations during deployment
@@ -116,15 +119,15 @@ specifying them in the `values.yaml` file). See the examples given below.
 -   Setting the custom Micro Integrator Docker image. 
 
     ```bash
-    --set wso2.deployment.mi.dockerRegistry=<CUSTOM_IMAGE_REGISTRY>
-    --set wso2.deployment.mi.imageName=<CUSTOM_IMAGE_NAME>
-    --set wso2.deployment.mi.imageTag=<CUSTOM_IMAGE_TAG>
+    --set containerRegistry=<CUSTOM_IMAGE_REGISTRY>
+    --set wso2.deployment.image.repository=<CUSTOM_IMAGE_REPOSITORY>
+    --set wso2.deployment.image.tag=<CUSTOM_IMAGE_TAG>
     ```
 
 -   Use the following parameter only if your custom Docker image is stored in a private Docker registry.
 
     ```bash
-    --set wso2.deployment.mi.imagePullSecrets=<IMAGE_PULL_SECRET>
+    --set wso2.deployment.imagePullSecrets=<IMAGE_PULL_SECRET>
     ```
 
 Your Micro Integrator Kubernetes cluster should now be created.
@@ -141,17 +144,15 @@ Go to your Kubernetes cluster from your terminal and follow the steps given belo
 
     Example:
 
-    ```bash
-    NAME                                                 HOSTS                      ADDRESS        PORTS     AGE
-    <RELEASE_NAME>-micro-integrator-service-ingress      mi.wso2.com                <EXTERNAL-IP>  80, 443   3m
-    <RELEASE_NAME>-micro-integrator-management-ingress   management.mi.wso2.com     <EXTERNAL-IP>  80, 443   3m
+    ```log
+    NAME            CLASS   HOSTS         ADDRESS        PORTS     AGE
+    cloud-<RELEASE_NAME>   nginx   mi.wso2.com   <EXTERNAL-IP>   80, 443   27m
     ```
 
 2.  Add the above hosts in the `/etc/hosts` file as follows:
 
     ```bash
     <EXTERNAL-IP>   mi.wso2.com 
-    <EXTERNAL-IP>   management.mi.wso2.com 
     ```
 
 3.  Execute the following command to invoke health check services:
@@ -160,10 +161,10 @@ Go to your Kubernetes cluster from your terminal and follow the steps given belo
     curl https://mi.wso2.com/healthz -k
     ```
     
-## What's Next?
+## What's next?
 
 Note that these instructions are for setting up a standalone deployment of the Micro Integrator. To set up one of the recommended deployment patterns, see the following topics:
 
-- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager](https://github.com/wso2/kubernetes-apim/blob/4.3.x/advanced/am-pattern-1/README.md)
-- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/4.3.x/advanced/am-pattern-2/README.md)
-- Using Helm Resources for a [Simple Scalable Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/4.3.x/advanced/am-pattern-3/README.md)
+- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-1/README.md)
+- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-2/README.md)
+- Using Helm Resources for a [Simple Scalable Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-3/README.md)

--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -35,7 +35,7 @@ Let's refer to the root folder of the local copy as `<HELM_HOME>`.
 
 ## Step 2 - Update the deployment configurations 
 
-Follow the steps given below to configure how your Micro Integrator deployment should be set up.
+Follow the steps below to configure how your Micro Integrator deployment should be set up.
 
 1. Open the `values.yaml` file in the `<HELM_HOME>/mi` folder of your local copy.
 

--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -1,6 +1,6 @@
 # Deploy the Micro Integrator on Kubernetes using Helm resources
 
-Follow the instructions given below to deploy the Micro Integrator on Kubernetes (K8s) using Helm resources.
+Follow the instructions below to deploy the Micro Integrator on Kubernetes (K8s) using Helm resources.
 
 ## Before you begin
     

--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -160,11 +160,3 @@ Go to your Kubernetes cluster from your terminal and follow the steps given belo
     ```bash
     curl https://mi.wso2.com/healthz -k
     ```
-    
-## What's next?
-
-Note that these instructions are for setting up a standalone deployment of the Micro Integrator. To set up one of the recommended deployment patterns, see the following topics:
-
-- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-1/README.md)
-- Using Helm Resources for a [Standard HA Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-2/README.md)
-- Using Helm Resources for a [Simple Scalable Deployment of WSO2 API Manager with Multitenancy](https://github.com/wso2/kubernetes-apim/blob/master/advanced/am-pattern-3/README.md)

--- a/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-micro-integrator-with-helm.md
@@ -1,19 +1,19 @@
-# Deploying the Micro Integrator on Kubernetes using Helm Resources
+# Deploy the Micro Integrator on Kubernetes using Helm resources
 
 Follow the instructions given below to deploy the Micro Integrator on Kubernetes (K8s) using Helm resources.
 
 ## Before you begin
     
--   Be sure you have an active [WSO2 Subscription](https://wso2.com/subscription). If you don't already have a subscription, sign up for a [WSO2 Free Trial Subscription](https://wso2.com/free-trial-subscription).
+- Be sure you have an active [WSO2 Subscription](https://wso2.com/subscription). If you don't have a subscription, sign up for a [WSO2 Free Trial Subscription](https://wso2.com/free-trial-subscription).
 
     !!! Note
         You need an active subscription to use the updated Docker images of the Micro Integrator with your Helm resources. Otherwise, you can use the community version of Docker images, which do not include product updates.
     
--   Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Helm](https://helm.sh/docs/intro/install/), and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+- Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Helm](https://helm.sh/docs/intro/install/), and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
     
--   Set up a [Kubernetes cluster](https://kubernetes.io/docs/setup/#learning-environment).
+- Set up a [Kubernetes cluster](https://kubernetes.io/docs/setup/#learning-environment).
     
--   Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/). 
+- Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/). 
 
     !!! Note
         Helm resources for WSO2 product deployment patterns are compatible with the ingress-nginx [`controller-v1.11.2`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.2) release.
@@ -22,8 +22,8 @@ Follow the instructions given below to deploy the Micro Integrator on Kubernetes
 
 Check out the Helm Resources for the WSO2 Micro Integrator Git repository.
 
-1.  Open a terminal and navigate to the location where you want to save the local copy.
-2.  Clone the Micro Integrator Git repository with Helm resources:
+1. Open a terminal and navigate to the location where you want to save the local copy.
+2. Clone the Micro Integrator Git repository with Helm resources:
 
     ```bash
     git clone https://github.com/wso2/helm-mi.git
@@ -37,11 +37,11 @@ Let's refer to the root folder of the local copy as `<HELM_HOME>`.
 
 Follow the steps given below to configure how your Micro Integrator deployment should be set up.
 
-1.  Open the `values.yaml` file in the `<HELM_HOME>/mi` folder of your local copy.
+1. Open the `values.yaml` file in the `<HELM_HOME>/mi` folder of your local copy.
 
-2.  Use the following guidelines to update the deployment configurations:
+2. Use the following guidelines to update the deployment configurations:
 
-    -   **Updating the WSO2 subscription details**
+    - **Update the WSO2 subscription details**
     
         You can update the user name and password in the following section. If you don't have an active WSO2 subscription, leave these parameters empty.
     
@@ -54,7 +54,7 @@ Follow the steps given below to configure how your Micro Integrator deployment s
 
         Alternatively, you can skip this step and pass your subscription details at the time of deploying (see the next step for details).
 
-    -   **Updating the Micro Integrator Docker images**
+    - **Update the Micro Integrator Docker images**
 
         By default, the `values.yaml` file uses the base Micro Integrator image (which does not include any integrations) to set up the deployment.
 
@@ -78,27 +78,27 @@ Follow the steps given below to configure how your Micro Integrator deployment s
                     tag: "<custom_image_tag>"
         ```
 
-    -   You can update [other configurations](https://github.com/wso2/helm-mi/blob/main/mi/EXAMPLES.md) as required.
+    - You can update [other configurations](https://github.com/wso2/helm-mi/blob/main/mi/EXAMPLES.md) as required.
 
-3.  Save the `values.yaml` file.
+3. Save the `values.yaml` file.
 
 ## Step 3 - Deploy the Micro Integrator
 
 Once you have set up your Helm resources locally, follow the instructions given below to set up the deployment.
 
-1.  Open a terminal and navigate to the `<HELM_HOME>/mi` folder.
-2.  Execute the command that is relevant to your Helm version.
+1. Open a terminal and navigate to the `<HELM_HOME>/mi` folder.
+2. Execute the command that is relevant to your Helm version.
 
     !!! Tip
         Be sure to replace `NAMESPACE` with the Kubernetes namespace in which your resources are deployed.
 
-    -   Using **Helm v2**
+    - Using **Helm v2**
         
         ```bash
         helm install --name <RELEASE_NAME> ./ -f values.yaml -n <NAMESPACE>
         ```
 
-    -   Using **Helm v3**
+    - Using **Helm v3**
         
         ```bash
         helm install <RELEASE_NAME> ./ -f values.yaml -n <NAMESPACE> --create-namespace
@@ -109,14 +109,14 @@ Once you have set up your Helm resources locally, follow the instructions given 
 If required, you can set any of the deployment configurations at the time of running the deployment (instead of
 specifying them in the `values.yaml` file). See the examples given below.
 
--   Setting the subscription username and password.
+- Set the subscription username and password.
 
     ```bash
     --set wso2.subscription.username=<SUBSCRIPTION_USERNAME>
-    --set wso2.subscription.username=<SUBSCRIPTION_USERNAME>
+    --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
     ```
 
--   Setting the custom Micro Integrator Docker image. 
+- Set the custom Micro Integrator Docker image. 
 
     ```bash
     --set containerRegistry=<CUSTOM_IMAGE_REGISTRY>
@@ -124,7 +124,7 @@ specifying them in the `values.yaml` file). See the examples given below.
     --set wso2.deployment.image.tag=<CUSTOM_IMAGE_TAG>
     ```
 
--   Use the following parameter only if your custom Docker image is stored in a private Docker registry.
+- Use the following parameter only if your custom Docker image is stored in a private Docker registry.
 
     ```bash
     --set wso2.deployment.imagePullSecrets=<IMAGE_PULL_SECRET>
@@ -136,7 +136,7 @@ Your Micro Integrator Kubernetes cluster should now be created.
 
 Go to your Kubernetes cluster from your terminal and follow the steps given below.
 
-1.  Get the external IP (`EXTERNAL-IP`) of the Ingress resources by listing down the Kubernetes Ingresses.
+1. Get the external IP (`EXTERNAL-IP`) of the Ingress resources by listing down the Kubernetes Ingresses.
 
     ```bash
     kubectl get ing -n <NAMESPACE>
@@ -149,13 +149,13 @@ Go to your Kubernetes cluster from your terminal and follow the steps given belo
     cloud-<RELEASE_NAME>   nginx   mi.wso2.com   <EXTERNAL-IP>   80, 443   27m
     ```
 
-2.  Add the above hosts in the `/etc/hosts` file as follows:
+2. Add the above hosts in the `/etc/hosts` file as follows:
 
     ```bash
     <EXTERNAL-IP>   mi.wso2.com 
     ```
 
-3.  Execute the following command to invoke health check services:
+3. Execute the following command to invoke health check services:
     
     ```bash
     curl https://mi.wso2.com/healthz -k


### PR DESCRIPTION
- Update document to MI 4.3.0
- Removed `What's next` part because the content removed from MI.
- Repo changed ( `https://github.com/wso2/kubernetes-mi.git` to `https://github.com/wso2/helm-mi.git`)