### PR TITLE
Update amazonsqs-connector-2.x-reference.md

### DIFF
--- a/en/docs/reference/connectors/amazonsqs-connector/2.x/amazonsqs-connector-2.x-reference.md
+++ b/en/docs/reference/connectors/amazonsqs-connector/2.x/amazonsqs-connector-2.x-reference.md
@@ -74,6 +74,13 @@ To use the Amazon SQS connector, first create the connection with your configura
     </table>
 
     !!! note
+        If you want to define any time out config in milliseconds use the decimal format in seconds.
+        
+        ```    
+        350 milliseconds can be expressed as 0.35 seconds 
+        ``` 
+
+    !!! note
         You can either pass credentials within init configuration or set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as environment variables. The AWS SDK uses provider chains to look for AWS credentials in system/user environment variables.
         To set these environment variables follow the below steps based on your operating system: 
     


### PR DESCRIPTION
## Purpose
> To instruct on time out configs defined in miliseconds.