### PR TITLE
Fix outdated endpoint mediator usage in consuming-jms example

### DIFF
--- a/en/docs/learn/examples/jms-examples/consuming-jms.md
+++ b/en/docs/learn/examples/jms-examples/consuming-jms.md
@@ -17,10 +17,12 @@ See the instructions on how to [build and run](#build-and-run) this example.
         <inSequence>
             <header name="Action" value="urn:getQuote"/>
             <property action="set" name="OUT_ONLY" value="true"/>
-        </inSequence>     
-        <endpoint>
-            <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
-        </endpoint>
+            <call>
+                <endpoint>
+                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+                </endpoint>
+            </call>
+        </inSequence>
     </target>
     <parameter name="transport.jms.ConnectionFactory">myQueueConnectionFactory</parameter>
     <parameter name="transport.jms.ContentType">

--- a/en/docs/learn/examples/jms-examples/publish-subscribe-with-jms.md
+++ b/en/docs/learn/examples/jms-examples/publish-subscribe-with-jms.md
@@ -19,12 +19,15 @@ Shown below are the synapse artifacts that are used to define this use case. See
     ```xml
     <proxy name="StockQuoteProxy" transports="http" startOnLoad="true" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
       <target>
-        <endpoint>
-          <address uri="jms:/SimpleStockQuoteService?transport.jms.ConnectionFactoryJNDIName=TopicConnectionFactory&amp;java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;java.naming.provider.url=tcp://localhost:61616&amp;transport.jms.DestinationType=topic"/>
-        </endpoint>
         <inSequence>
-            <property name="OUT_ONLY" value="true"/>
-            <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2"/>
+            <property name="OUT_ONLY" value="true" />
+            <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2" />
+            <call>
+                <endpoint>
+                    <address
+                        uri="jms:/SimpleStockQuoteService?transport.jms.ConnectionFactoryJNDIName=TopicConnectionFactory&amp;java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;java.naming.provider.url=tcp://localhost:61616&amp;transport.jms.DestinationType=topic" />
+                </endpoint>
+            </call>
         </inSequence>
       </target>
     </proxy> 


### PR DESCRIPTION
Related: https://github.com/wso2/mi-vscode/issues/854

Fix the outdated usage of the endpoint mediator in https://mi.docs.wso2.com/en/4.4.0/learn/examples/jms-examples/consuming-jms/ and https://mi.docs.wso2.com/en/4.4.0/learn/examples/jms-examples/publish-subscribe-with-jms/ .