### PR TITLE
Fix version dropdown issue

### DIFF
--- a/en/docs/assets/versions.json
+++ b/en/docs/assets/versions.json
@@ -14,7 +14,7 @@
     "4.3.0":{
         "doc": "https://mi.docs.wso2.com/en/4.3.0/",
         "notes": "https://mi.docs.wso2.com/en/4.3.0/get-started/about-this-release/"
-    }
+    },
     "4.2.0":{
         "doc": "https://mi.docs.wso2.com/en/4.2.0/",
         "notes": "https://mi.docs.wso2.com/en/4.2.0/get-started/about-this-release/"


### PR DESCRIPTION
## Purpose

The version dropdown is not shown due to a syntax issue in versions.json. This PR fixes the syntax issue