### PR TITLE
Rename old expressions to legacy expressions

### DIFF
--- a/en/docs/learn/samples/synapse-expressions.md
+++ b/en/docs/learn/samples/synapse-expressions.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.8
+---
+
 # Synapse Expressions Sample
 
 This sample contains a REST API that demonstrates the use of **Synapse Expressions** in WSO2 Micro Integrator.

--- a/en/docs/reference/synapse-properties/expressions.md
+++ b/en/docs/reference/synapse-properties/expressions.md
@@ -1,4 +1,12 @@
-# Expressions
+---
+search:
+  boost: 0.5
+---
+
+# Legacy Expressions
+
+!!! Note
+    WSO2 Micro Integrator will continue to support existing XPath and JSONPath expressions. However, it is recommended to use the new [Synapse Expressions]({{base_path}}/reference/synapse-properties/synapse-expressions), as they simplify data extraction and provide a rich set of functions.
 
 In WSO2 Micro Integrator, expressions are a way to dynamically compute values within various integration artifacts such as sequences, APIs, endpoints, and proxies. These expressions are used to extract data as it flows through the integration logic.
 

--- a/en/docs/reference/synapse-properties/jsonpath-expressions.md
+++ b/en/docs/reference/synapse-properties/jsonpath-expressions.md
@@ -1,4 +1,12 @@
+---
+search:
+  boost: 0.4
+---
+
 # JSONPath Expressions
+
+!!! Note
+    WSO2 Micro Integrator will continue to support existing JSONPath expressions. However, it is recommended to use the new [Synapse Expressions]({{base_path}}/reference/synapse-properties/synapse-expressions), as they simplify data extraction and provide a rich set of functions.
 
 [JSONPath](http://goessner.net/articles/JsonPath/) expressions are used for navigating and querying JSON data. JSONPath allows you to extract specific data from JSON documents.
 

--- a/en/docs/reference/synapse-properties/rest-api-properties.md
+++ b/en/docs/reference/synapse-properties/rest-api-properties.md
@@ -112,8 +112,8 @@ When you are creating a REST API artifact, you need to configure the API resourc
             </table>
         <div class="admonition info">
             <p class="admonition-title">Info</p>
-            <p>It is possible to retrieve the exact values of the two variables using the <a href="{{base_path}}/reference/synapse-properties/expressions/#get-property-function">get-property</a> expression and prefixing the variable with <code>uri.var</code>.</p>
-            <p>For example: <code>&lt;property name=&quot;char&quot; expression=&quot;get-property(&#39;uri.var.char&#39;)&quot;/&gt;</code></p>
+            <p>You can retrieve the values of the two path parameters using <code>params.pathParams</code>. For more information, refer to <a href="{{base_path}}/reference/synapse-properties/synapse-expressions-syntax/#access-query-and-path-parameters">Access query and path parameters</a>.
+            <p>For example: <code>&lt;variable name=&quot;word&quot; expression=&quot;${params.pathParams.word}&quot;/&gt;</code></p>
         </div>
         <div class="admonition note">
             <p class="admonition-title">Note</p>

--- a/en/docs/reference/synapse-properties/synapse-expressions-syntax.md
+++ b/en/docs/reference/synapse-properties/synapse-expressions-syntax.md
@@ -1,4 +1,4 @@
-# Synapse Expressions Syntax
+# Expressions Syntax
 
 **Synapse Expressions** are identified by the enclosing `${}` syntax. 
 

--- a/en/docs/reference/synapse-properties/synapse-expressions.md
+++ b/en/docs/reference/synapse-properties/synapse-expressions.md
@@ -1,4 +1,4 @@
-# Synapse Expressions
+# Expressions
 
 ## Overview
 

--- a/en/docs/reference/synapse-properties/xpath-expressions.md
+++ b/en/docs/reference/synapse-properties/xpath-expressions.md
@@ -1,4 +1,12 @@
+---
+search:
+  boost: 0.4
+---
+
 # XPath Expressions
+
+!!! Note
+    WSO2 Micro Integrator will continue to support existing XPath expressions. However, it is recommended to use the new [Synapse Expressions]({{base_path}}/reference/synapse-properties/synapse-expressions), as they simplify data extraction and provide a rich set of functions.
 
 [XPath (XML Path Language)](https://www.w3schools.com/xml/xpath_intro.asp) is a language used to navigate through elements and attributes in an XML document. It allows you to identify and extract specific portions of XML data, making it ideal for working with complex XML payloads, which are common in service integration scenarios.
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -852,7 +852,7 @@ nav:
           - Comparison with JSONPath : reference/synapse-properties/synapse-expressions-comparison.md 
           - Legacy Expressions:
               - Overview: reference/synapse-properties/expressions.md
-              - JSONPath expressions: reference/synapse-properties/jsonpath-expressions.md
+              - JSONPath Expressions: reference/synapse-properties/jsonpath-expressions.md
               - XPath Expressions: reference/synapse-properties/xpath-expressions.md
       - Scopes: reference/synapse-properties/scopes.md
       - Templates: reference/synapse-properties/template-properties.md

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -847,13 +847,13 @@ nav:
           - Axis2 Properties: reference/mediators/property-reference/axis2-properties.md
           - Synapse Message Context Properties: reference/mediators/property-reference/message-context-properties.md
       - Expressions:
-          - Expressions Overview: reference/synapse-properties/expressions.md
-          - JSONPath expressions: reference/synapse-properties/jsonpath-expressions.md
-          - XPath Expressions: reference/synapse-properties/xpath-expressions.md
-          - Synapse Expressions:
-              - Overview: reference/synapse-properties/synapse-expressions.md
-              - Syntax: reference/synapse-properties/synapse-expressions-syntax.md
-              - Comparison with JSONPath : reference/synapse-properties/synapse-expressions-comparison.md
+          - Overview: reference/synapse-properties/synapse-expressions.md
+          - Syntax: reference/synapse-properties/synapse-expressions-syntax.md
+          - Comparison with JSONPath : reference/synapse-properties/synapse-expressions-comparison.md 
+          - Legacy Expressions:
+              - Overview: reference/synapse-properties/expressions.md
+              - JSONPath expressions: reference/synapse-properties/jsonpath-expressions.md
+              - XPath Expressions: reference/synapse-properties/xpath-expressions.md
       - Scopes: reference/synapse-properties/scopes.md
       - Templates: reference/synapse-properties/template-properties.md
       - Mediation Sequences: reference/mediation-sequences.md


### PR DESCRIPTION
## Purpose

1. Rename old expressions to legacy expressions.

<img width="2015" alt="Screenshot 2025-03-12 at 13 38 18" src="https://github.com/user-attachments/assets/d00214b2-8a39-4976-8cb5-51c007fd91e3" />

2. Reduce search index for legacy expressions.

<img width="1693" alt="Screenshot 2025-03-12 at 13 38 30" src="https://github.com/user-attachments/assets/e872d993-96ef-4bdf-8cf5-30961fb05202" />

Fixes: https://github.com/wso2/docs-mi/issues/1464