### PR TITLE
Add notes referencing improved mediators and connectors in the reference documentation

### DIFF
--- a/en/docs/learn/examples/endpoint-examples/using-http-endpoints.md
+++ b/en/docs/learn/examples/endpoint-examples/using-http-endpoints.md
@@ -1,5 +1,8 @@
 # How to Use an HTTP Endpoint
 
+!!! Note  
+    Starting from WSO2 MI 4.4.0, a new [**HTTP Connector**]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) is available for invoking HTTP backends. While **HTTP endpoints** can still be used, the HTTP connector provides a more flexible and feature-rich approach for handling HTTP requests. It is **recommended** to use the [HTTP Connector]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) for new implementations.
+
 See the examples given below on how to effectively use the HTTP endpoint.
 
 ## Example 1: Populate an HTTP endpoint during mediation

--- a/en/docs/reference/mediators/aggregate-mediator.md
+++ b/en/docs/reference/mediators/aggregate-mediator.md
@@ -1,5 +1,8 @@
 # Aggregate Mediator
 
+!!! Note  
+      From WSO2 MI 4.4.0 onwards, if your use case requires processing and merging multiple message flows, you don't need to use the **Clone Mediator** along with the **Aggregate Mediator**. Instead, you can use the [**Scatter Gather mediator**]({{base_path}}/reference/mediators/scatter-gather-mediator/) as a single-step solution, simplifying the integration flow. It is recommended to use the [**Scatter Gather mediator**]({{base_path}}/reference/mediators/scatter-gather-mediator/) for new implementations.
+
 The **Aggregate mediator** implements the [Aggregator enterprise integration pattern]({{base_path}}/learn/enterprise-integration-patterns/message-routing/aggregator/). It
 combines (aggregates) the **response messages** of messages that were split by the split by the [Clone]({{base_path}}/reference/mediators/clone-mediator) or
 [Iterate]({{base_path}}/reference/mediators/iterate-mediator) mediator. Note that the responses are not necessarily aggregated in the same order that the requests were sent,

--- a/en/docs/reference/mediators/call-mediator.md
+++ b/en/docs/reference/mediators/call-mediator.md
@@ -1,5 +1,8 @@
 # Call Mediator
 
+!!! Note  
+    Starting from WSO2 MI 4.4.0, a new [**HTTP Connector**]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) is available for invoking HTTP backends. While the **Call Mediator** can still be used, the HTTP connector provides a more flexible and feature-rich approach for handling HTTP requests. It is **recommended** to use the [HTTP Connector]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) for new implementations.
+
 The **Call mediator** is used to send messages out of the Micro Integrator to an **endpoint**. You can invoke services either in blocking or non-blocking manner.
 
 When you invoke a service in non-blocking mode, the underlying worker

--- a/en/docs/reference/mediators/clone-mediator.md
+++ b/en/docs/reference/mediators/clone-mediator.md
@@ -1,5 +1,8 @@
 # Clone Mediator
 
+!!! Note  
+      From WSO2 MI 4.4.0 onwards, if your use case requires processing and merging multiple message flows, you don't need to use the **Clone Mediator** along with the **Aggregate Mediator**. Instead, you can use the [**Scatter Gather mediator**]({{base_path}}/reference/mediators/scatter-gather-mediator/) as a single-step solution, simplifying the integration flow. It is recommended to use the [**Scatter Gather mediator**]({{base_path}}/reference/mediators/scatter-gather-mediator/) for new implementations.
+
 The **Clone Mediator** can be used to clone a message into several messages. It resembles the [Scatter-Gather enterprise integration pattern]({{base_path}}/learn/enterprise-integration-patterns/message-routing/scatter-gather/). The Clone mediator is similar to the [Iterate mediator]({{base_path}}/reference/mediators/iterate-mediator). The difference between the two mediators is that the Iterate mediator splits a message into different parts, whereas the Clone mediator makes multiple identical copies of the message.
 
 !!! Info

--- a/en/docs/reference/mediators/iterate-mediator.md
+++ b/en/docs/reference/mediators/iterate-mediator.md
@@ -1,18 +1,17 @@
 # Iterate Mediator
 
+!!! Note  
+        From WSO2 MI 4.4.0 onwards, you can use the [**ForEach mediator**]({{base_path}}/reference/mediators/foreach-mediator/) instead of the **Iterate mediator**. The [**ForEach mediator**]({{base_path}}/reference/mediators/foreach-mediator/) includes all the functionality of the Iterate mediator and eliminates the need to use the **Aggregate mediator** to merge flows. It provides a more streamlined and efficient way to process individual elements in a message payload. It is recommended to use the [**ForEach mediator**]({{base_path}}/reference/mediators/foreach-mediator/) for new implementations.
+
 The Iterate Mediator implements the [Splitter enterprise integration pattern]({{base_path}}/learn/enterprise-integration-patterns/message-routing/splitter/) and splits the message into several different messages derived from the parent message.
 
 !!! Info
     The Iterate mediator is similar to the [Clone mediator]({{base_path}}/reference/mediators/clone-mediator). The difference between the two mediators is, that the Iterate mediator splits a message into different parts, whereas the Clone mediator makes multiple identical copies of the message.
 
 !!! Info
-    Iterate Mediator is quite similar to the [ForEach mediator]({{base_path}}/reference/mediators/foreach-mediator). You can use complex expressions to conditionally select elements to iterate over in both mediators. Following are the main differences between ForEach and Iterate mediators:
-    
-    -   Use the ForEach mediator only for message transformations. If you need to make back-end calls from each iteration, use the iterate mediator.
-    -   The ForEach mediator supports modifying the original payload. You can use the Iterate mediator for situations where you send the split messages to a target and collect them by an [Aggreagte]({{base_path}}/reference/mediators/aggregate-mediator) mediator in a different flow.
-    -   You need to always accompany an Iterate mediator with an Aggregate mediator to aggregate responses. For [out-only (fire-and-forget) invocations]({{base_path}}/reference/mediators/property-reference/generic-properties/#out_only), Aggregate mediator is not needed, as there is no response to aggregate. ForEach mediator loops over the sub-messages and merges them back to the same parent element of the message.
-    -   In Iterate mediator, you need to send the split messages to an endpoint to continue the message flow. However, ForEach mediator does not allow using [Call]({{base_path}}/reference/mediators/call-mediator), [Send]({{base_path}}/reference/mediators/send-mediator) and [Callout]({{base_path}}/reference/mediators/callout-mediator) mediators in the sequence.
-    -   The ForEach mediator does not split the message flow, unlike the Iterate mediator. It guarantees execution in the same thread until all iterations are complete.
+    -   You can use complex expressions to conditionally select elements to iterate over in the Iterate mediator.
+    -   You need to always accompany an Iterate mediator with an Aggregate mediator to aggregate responses. For [out-only (fire-and-forget) invocations]({{base_path}}/reference/mediators/property-reference/generic-properties/#out_only), Aggregate mediator is not needed, as there is no response to aggregate. 
+    -   In Iterate mediator, you need to send the split messages to an endpoint to continue the message flow.
 
 !!! Info
     When using the Iterate Mediator, the message is cloned for each iteration, including properties with the [default scope]({{base_path}}/reference/synapse-properties/scopes/#default-scope). If a property contains a large amount of data, this duplication can cause performance overhead.

--- a/en/docs/reference/mediators/property-mediator.md
+++ b/en/docs/reference/mediators/property-mediator.md
@@ -1,6 +1,9 @@
 # Property mediator
 
-The Property mediator is used to manage message properties within a mediation flow. Properties in WSO2 MI are key-value pairs that can be used to store and retrieve values during message processing. The Property Mediator allows you to set or remove these properties, which can then be used later in the mediation flow.
+The Property mediator is used to define configuration settings that control how an integration behaves. These properties manage transport settings, security configurations, or mediator-specific parameters that influence message processing. The Property mediator allows you to set or remove these properties, ensuring they are available within the mediation flow.
+
+!!! Note
+    With the introduction of the [**Variable mediator**]({{base_path}}/reference/mediators/variable-mediator/) in WSO2 MI 4.4.0 onwards, it is now recommended to use the **Property mediator** only for managing configuration-related properties within a mediation flow. To store data for future use, the [**Variable mediator**]({{base_path}}/reference/mediators/variable-mediator/) should be used instead.
 
 ## Syntax
 
@@ -126,18 +129,6 @@ The parameters available to configure the property mediator are as follows:
 
 ## Examples
 
-### Set and log and property
-
-In this example, we are setting the property symbol, and later we can log it using the [Log Mediator]({{base_path}}/reference/mediators/log-mediator).
-
-```xml
-<property name="symbol" expression="fn:concat('Normal Stock - ', //m0:getQuote/m0:request/m0:symbol)" xmlns:m0="http://services.samples/xsd"/>
-
-<log level="custom">
-    <property name="symbol" expression="$ctx:symbol"/>
-</log>
-```
-
 ### Send a fault message based on the Accept http header
 
 In this configuration, a response is sent to the client based on the `Accept` header. The [PayloadFactory mediator]({{base_path}}/reference/mediators/payloadfactory-mediator) transforms the message contents. Then a [Property mediator]({{base_path}}/reference/mediators/property-mediator) sets the message type
@@ -157,69 +148,10 @@ based on the `Accept` header using the `$ctx:accept` expression. The message is 
 <respond/>
 ```
 
-### Read a property stored in the Registry
+### Set the HTTP status code
 
-You can read a property that is stored in the Registry by using the `get-property()` method in your Synapse configuration. 
-For example, the following Synapse configuration retrieves the `abc` property of the collection `gov:/data/xml/collectionx`, and stores it in the `regProperty` property.
-
-``` xml
-<property name="regProperty" expression="get-property('registry', 'gov:/data/xml/collectionx@abc')"/>
-```
-
-!!! Info
-    You can use the following syntax to read properties or resources stored in the `gov` or `conf` registries. When specifying the path to the resource, do not give the absolute path. Instead, use the `gov` or `conf` prefixes.
-
-#### Read a property stored under a collection
-
--   `get-property('registry','gov:<path to resource from governance>@<propertyname>')`
--   `get-property('registry','conf:<path to resource from config>@<propertyname>')`
-
-#### Read a property stored under a resource
-
--   `get-property('registry','gov:<path to resource from governance>/@<propertyname>')`
--   `get-property('registry','conf:<path to resource from config>/@<propertyname>')`
-
-#### Read an XML resource
-
--   `get-property('registry','gov:<path to resource from governance>')`
--   `get-property('registry','conf:<path to resource from config>')`
-
-### Read a file stored in the Registry
-
-Following is an example, in which you read an XML file that is stored in the registry using an [expression]({{base_path}}/reference/synapse-properties/expressions), to retrieve a value from it. Assume you have the following XML file stored in the registry in the path `gov:/test.xml`.
-
-**test.xml**
+The Property mediator can be used to set the HTTP status code for responses. In the example below, the status code is set to `500`,
 
 ```xml
-<root>
-  <book>A Song of Ice and Fire</book>
-  <author>George R. R. Martin</author>
-</root>
-```
-
-In the mediation flow, you can use the following expression to read XML.
-
-**reg_xpath.xml**
-
-``` xml
-<property name="xmlFile" expression="get-property('registry','gov:/test.xml')" scope="default" type="OM"></property>
-<log level="custom">
-    <property name="Book_Name" expression="$ctx:xmlFile//book"></property>
-</log>
-```
-
-Your output log will look like this.
-
-``` text
-[2015-09-21 16:01:28,750]  INFO - LogMediator Book_Name = A Song of Ice and Fire
-```
-
-### Read SOAP headers
-
-SOAP headers provide information about the message, such as the To and From values. You can use the `get-property()` function in the Property mediator to retrieve these headers. See the [SOAP headers]({{base_path}}/reference/mediators/property-reference/soap-headers) documentation for more information.
-
-For example, the following property stores the `To` header.
-
-```xml
-<property name="ToHeader" expression="get-property('To')" scope="axis2"/>
+<property name="HTTP_SC" value="500" scope="axis2"/>
 ```

--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -7,6 +7,9 @@ For example, the endpoint for the simple stock quote sample is `http://localhost
 
 Endpoints are independent of transports, which allows you to use the same endpoint with multiple transports. When you configure a message mediation sequence or a proxy service to handle the incoming message, you can specify which transport to use and the endpoint to which the message is sent.
 
+!!! Note  
+    Starting from WSO2 MI 4.4.0, a new [**HTTP Connector**]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) is available for invoking HTTP backends. While **HTTP endpoints** can still be used, the HTTP connector provides a more flexible and feature-rich approach for handling HTTP requests. It is **recommended** to use the [HTTP Connector]({{base_path}}/reference/connectors/http-connector/http-connector-overview/) for new implementations.
+
 ## Classification of Endpoints
 
 ### Named Endpoints


### PR DESCRIPTION
## Purpose
Add notes referencing improved mediators and connectors in the reference documentation.

**Property mediator reference doc**
![Screenshot 2025-03-17 at 15 14 20](https://github.com/user-attachments/assets/4e4eca6e-6cb4-48e2-ac3a-4a15ca55ed8f)

**Aggregate mediator reference doc**
![Screenshot 2025-03-17 at 15 12 02](https://github.com/user-attachments/assets/a87f81bc-2c44-4d06-a3e5-afaf673b94b3)

**Clone mediator reference doc**
![Screenshot 2025-03-17 at 15 12 17](https://github.com/user-attachments/assets/b234a097-7cdb-465e-9858-7f4f14654be3)

**Iterate mediator reference doc**
![Screenshot 2025-03-17 at 15 12 39](https://github.com/user-attachments/assets/3ce41132-4228-4cb9-9999-076a41dd0fd4)

**Call mediator reference doc**
![Screenshot 2025-03-17 at 15 12 59](https://github.com/user-attachments/assets/317a050d-736d-4d8f-93cd-b4566c0f7940)

**Endpoint reference doc**
![Screenshot 2025-03-17 at 15 13 26](https://github.com/user-attachments/assets/93823183-4e61-43d6-a778-025f429965e4)

## Related Issue
https://github.com/wso2/docs-mi/issues/1473