### PR TITLE
Fix page feedback title issue

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -215,7 +215,7 @@
                           </div>
                           <div data-md-value="0" hidden>
                             Thanks for your feedback! Help us improve this page by
-                            <a href="https://github.com/wso2/docs-mi/issues/new/?title=[Feedback]+{{ page.title | striptags }}+-+{{ page.url | striptags }}" target="_blank" rel="noopener">reporting a GitHub issue</a>.
+                            <a href="https://github.com/wso2/docs-mi/issues/new/?template=feedback.md&title=[Feedback]+{{ page.title | striptags }}+-+{{ page.url | striptags }}" target="_blank" rel="noopener">reporting a GitHub issue</a>.
                           </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Purpose

Fix page feedback title issue. Append an empty `feedback.md` to auto populate the git issue title with the page name and url.