### PR TITLE
[420] Update RabbitMQ config docs

### DIFF
--- a/en/docs/install-and-setup/setup/brokers/configure-with-rabbitmq.md
+++ b/en/docs/install-and-setup/setup/brokers/configure-with-rabbitmq.md
@@ -75,14 +75,6 @@ In case of a network failure or broker shutdown, WSO2 Micro Integrator will try 
 
 If the parameters specified above are set, the Micro Integrator will retry 5 times with 10000 ms time intervals to reconnect when the connection is lost. If reconnecting also fails, the Micro Integrator will terminate the connection. If you do not specify values for the above parameters, the Micro Integrator uses 30000ms as the default retry interval and 3 as the default retry count.
 
-Optionally, you can configure the following parameter in your proxy service when you define your mediation sequence:
-
-```xml
-<parameter name="rabbitmq.server.retry.interval" locked="false">10000</parameter> 
-```
-
-The parameter specified above sets the retry interval with which the RabbitMQ client tries to reconnect. Generally having this value less than the value specified as `rabbitmq.connection.retry.interval` will help synchronize the reconnection of the Micro Integrator and the RabbitMQ client.
-
 ## Configuring high throughput of message delivery
 
 For increased performance and higher throughput in message delivery, configure the transport sender as shown below.

--- a/en/docs/install-and-setup/setup/performance-tuning/rabbitmq-transport-tuning.md
+++ b/en/docs/install-and-setup/setup/performance-tuning/rabbitmq-transport-tuning.md
@@ -4,36 +4,20 @@ See the following topics to tune the RabbitMQ transport:
 
 ## Increase the connection pool size
 
-You can increase the connection pool size to improve the performance of the RabbitMQ sender and listener. The default connection pool size is 20. To change this, specify a required value for the following parameter in the RabbitMQ transport sender and listener configurations in the deployment.toml file (stored in the `MI_HOME/conf` directory).
-
-Sample configurations:
+You can increase the connection pool size to improve the performance of the RabbitMQ sender. The default connection pool size is 20. To change this, specify a required value for the `connection_pool_size` parameter in the RabbitMQ transport sender configurations in the deployment.toml file (stored in the `MI_HOME/conf` directory).
  
-=== "Sample Receiver"
-    ```toml 
-    [[transport.rabbitmq.listener]]
-    name = "rabbitMQListener"
-    parameter.connection_factory = "RabbitMQConnectionFactory"
-    parameter.hostname = "localhost"
-    parameter.port = 5672
-    parameter.username = "guest"
-    parameter.password = "guest"
-    parameter.retry_interval = "10s"
-    parameter.retry_count = 5
-    parameter.connection_pool_size = 25
-    ```
-=== "Sample Sender"    
-    ```toml 
-    [[transport.rabbitmq.sender]]
-    name = "rabbitMQSender"
-    parameter.connection_factory = "RabbitMQConnectionFactory"
-    parameter.hostname = "localhost"
-    parameter.port = 5672
-    parameter.username = "guest"
-    parameter.password = "guest"
-    parameter.retry_interval = "10s"
-    parameter.retry_count = 5
-    parameter.connection_pool_size = 25
-    ```
+```toml 
+[[transport.rabbitmq.sender]]
+name = "rabbitMQSender"
+parameter.connection_factory = "RabbitMQConnectionFactory"
+parameter.hostname = "localhost"
+parameter.port = 5672
+parameter.username = "guest"
+parameter.password = "guest"
+parameter.retry_interval = "10s"
+parameter.retry_count = 5
+parameter.connection_pool_size = 25
+```
 
 ## Increase the member count
 

--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -8213,7 +8213,6 @@ parameter.message_content_type = ""
 
 parameter.retry_interval = "10s"
 parameter.retry_count = 5
-parameter.connection_pool_size = 25
 
 parameter.ssl_enable = true
 parameter.ssl_version = "SSL"

--- a/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
@@ -110,12 +110,6 @@ present. If set to <code>false</code>, the Micro Integrator will assume that a q
          </td>
       </tr>
       <tr>
-         <td>rabbitmq.connection.pool.size</td>
-         <td>
-            You can increase the connection pool size to improve the performance of the RabbitMQ sender and listener. The default connection pool size is 20.
-         </td>
-      </tr>
-      <tr>
          <td>rabbitmq.publisher.confirms.enabled</td>
          <td>
             Enables support for RabbitMQ publisher confirms.
@@ -124,37 +118,7 @@ present. If set to <code>false</code>, the Micro Integrator will assume that a q
    </tbody>
 </table>
 
-### Connection Recovery Parameters (Optional)
-
-In case of a network failure or broker shutdown, the Micro Integrator will try to recreate the connection.
-
-<table>
-  <tr>
-    <th>Parameter</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>rabbitmq.connection.retry.interval</td>
-    <td>
-      The retry interval specifies how frequently (time interval) the Micro Integrator should retry to recreate a lost connection. The default value is <code>30000</code> ms. That is, the Micro Integrator retries to connect every 30000 miliseconds.
-    </td>
-  </tr>
-  <tr>
-    <td>rabbitmq.connection.retry.count</td>
-    <td>
-      The retry count specifies the number of times the Micro Integrator will try to recreate a lost connection. The default retry count is <code>3</code>. That is, the Micro Integrator retries only 3 times.
-    </td>
-  </tr>
-  <tr>
-    <td>rabbitmq.server.retry.interval</td>
-    <td>
-      This parameter is <b>optional</b>.</br>
-      The parameters specified above sets the retry interval with which the RabbitMQ client tries to reconnect. Generally having this value less than the value specified as <code>rabbitmq.connection.retry.interval</code> will help synchronize the reconnection of the Micro Integrator and the RabbitMQ client.
-    </td>
-  </tr>
-</table>
-
-### SSL Parameters (Optional)
+### SSL parameters (optional)
 
 To enable SSL support in RabbitMQ, you need to configure the following parameters.
 
@@ -359,7 +323,7 @@ In your integration solution, the following RabbitMQ send parameters can be spec
       <tr>
          <td>rabbitmq.connection.pool.size</td>
          <td>
-            You can increase the connection pool size to improve the performance of the RabbitMQ sender and listener. The default connection pool size is 20.
+            You can increase the connection pool size to improve the performance of the RabbitMQ sender. The default connection pool size is 20.
          </td>
       </tr>
    </tbody>


### PR DESCRIPTION
## Purpose

- Remove unused parameter `rabbitmq.server.retry.interval`
- Update connection pool size configs

Fixes: https://github.com/wso2/docs-mi/issues/1452