### PR TITLE
docs(mi): fix typos in README (referred, throughout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The WSO2 Integrator: MI documentation provides comprehensive guides, tutorials, 
 
   - `docs-mi/en/docs/` : Contains all the `.md` files with content.
 
-    > **Tip** :
+    > **Tip**:
     > `docs-mi/en/docs/` directory is referred to by {{base_path}} throughout the documentation.
 
     ```html


### PR DESCRIPTION
Fixed two typos in README.md:
- "reffered" → "referred"
- "through out" → "throughout"
