### PR TITLE
Update documentation to replace "Scheduled Task" with "Scheduled trig…

### DIFF
--- a/en/docs/develop/creating-artifacts/creating-scheduled-task.md
+++ b/en/docs/develop/creating-artifacts/creating-scheduled-task.md
@@ -1,6 +1,6 @@
-# Create a Scheduled Task
+# Create a Scheduled trigger
 
-Follow the instructions below to create a Scheduled Task in the WSO2 Integrator: MI for Visual Studio Code (MI for VS Code) extension.
+Follow the instructions below to create a Scheduled trigger in the WSO2 Integrator: MI for Visual Studio Code (MI for VS Code) extension.
 
 ## Create a scheduled task artifact
 
@@ -8,7 +8,7 @@ Follow the instructions below to create a Scheduled Task in the WSO2 Integrator:
 
     Hereafter, this project will be referred to as `<PROJECT_NAME>`.
 
-3. To add a new Scheduled Task, navigate to **WSO2 Integrator: MI Project Explorer**.
+3. To add a new Scheduled trigger, navigate to **WSO2 Integrator: MI Project Explorer**.
 
 4. Click on the **+** icon to open the **Add Artifact** pane.
 
@@ -46,7 +46,7 @@ You can later update the task configurations to specify the incoming message tha
 6. Click **Update**.
 
 !!! info
-    See the [Scheduled Tasks Property Catalog]({{base_path}}/reference/synapse-properties/scheduled-task-properties/) documentation for a list of all available configurations for tasks.
+    See the [Scheduled triggers Property Catalog]({{base_path}}/reference/synapse-properties/scheduled-task-properties/) documentation for a list of all available configurations for tasks.
 
 ## Tutorials
 

--- a/en/docs/develop/creating-unit-test-suite.md
+++ b/en/docs/develop/creating-unit-test-suite.md
@@ -7,7 +7,7 @@ Once you have developed an integration solution, WSO2 Integrator: MI VS Code Ext
 - Test the artifacts with [Connectors]({{base_path}}/develop/creating-artifacts/adding-connectors).
 
     !!! Note
-         [Scheduled Tasks]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) are not supported by the Unit Testing framework.
+         [Scheduled triggers]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) are not supported by the Unit Testing framework.
 
 ## Create Unit Test Suite
 

--- a/en/docs/develop/customizations/creating-custom-task-scheduling.md
+++ b/en/docs/develop/customizations/creating-custom-task-scheduling.md
@@ -317,7 +317,7 @@ Follow the steps below to create the task and schedule it.
 
     The below is the complete source configuration of the Sequence (i.e., the `PrintStockQuoteSequence.xml` file):
  
-6. [Create a Scheduled Task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) using the following information:
+6. [Create a Scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) using the following information:
     <table>
         <tr>
             <th>Task Property</th>

--- a/en/docs/develop/intro-integration-development.md
+++ b/en/docs/develop/intro-integration-development.md
@@ -72,7 +72,7 @@ To start developing integration solutions, you need to first <a href="{{base_pat
                         <a href="{{base_path}}/develop/creating-artifacts/creating-an-inbound-endpoint/">Inbound Endpoint</a>
                     </li>
                     <li>
-                        <a href="{{base_path}}/develop/creating-artifacts/creating-scheduled-task/">Scheduled Task</a>
+                        <a href="{{base_path}}/develop/creating-artifacts/creating-scheduled-task/">Scheduled trigger</a>
                     </li>
                 </ul>
             </td>
@@ -135,7 +135,7 @@ To start developing integration solutions, you need to first <a href="{{base_pat
                         <a href="{{base_path}}/develop/customizations/creating-new-connector/">Custom Connector</a>
                     </li>
                     <li>
-                        <a href="{{base_path}}/develop/customizations/creating-custom-task-scheduling/">Custom Scheduled Task</a>
+                        <a href="{{base_path}}/develop/customizations/creating-custom-task-scheduling/">Custom Scheduled trigger</a>
                     </li>
                     <li>
                         <a href="{{base_path}}/develop/customizations/creating-synapse-handlers/">Synapse Handler</a>

--- a/en/docs/get-started/key-concepts.md
+++ b/en/docs/get-started/key-concepts.md
@@ -93,11 +93,11 @@ A Data service allows users to expose data from various data sources such as dat
 
 See the [Data Services]({{base_path}}/reference/synapse-properties/data-services) documentation for more information.
 
-#### Scheduled Tasks
+#### Scheduled triggers
 
 Executing an integration process at a specified time is a common requirement in enterprise integration. For example, in an organization, there can be a need to run an integration process to synchronize two systems every day at the end of the day. In the WSO2 Integrator: MI, the execution of a message mediation process can be automated to run periodically by using a scheduled task. Furthermore, you can use cron expressions for more advanced scheduling configurations.
 
-See the [Scheduled Tasks]({{base_path}}/reference/synapse-properties/scheduled-task-properties) documentation for more information.
+See the [Scheduled triggers]({{base_path}}/reference/synapse-properties/scheduled-task-properties) documentation for more information.
 
 #### Transports
 

--- a/en/docs/install-and-setup/setup/deployment/configuring-helm-charts.md
+++ b/en/docs/install-and-setup/setup/deployment/configuring-helm-charts.md
@@ -287,7 +287,7 @@ wso2:
 
 ## Coordination configurations
 
-This is an **optional configuration**, required only if you plan to deploy stateful artifacts such as Scheduled Tasks, Message Processors, or Polling and Event-based Inbound Endpoints across multiple replicas. These artifacts require coordination to prevent duplicate executions and ensure consistent behavior across the cluster.
+This is an **optional configuration**, required only if you plan to deploy stateful artifacts such as Scheduled triggers, Message Processors, or Polling and Event-based Inbound Endpoints across multiple replicas. These artifacts require coordination to prevent duplicate executions and ensure consistent behavior across the cluster.
 
 Update the following values in your `values.yaml` file.
 

--- a/en/docs/install-and-setup/setup/deployment/deploying-wso2-mi.md
+++ b/en/docs/install-and-setup/setup/deployment/deploying-wso2-mi.md
@@ -42,7 +42,7 @@ See the descriptions of the [service catalog parameters]({{base_path}}/reference
 
 Most of the integration artifacts in your deployment are stateless and don't actually require coordination when there is more than a single instance of the server running. However, the following set of artifacts require coordination among themselves when deployed in more than a single instance of the server.
 
--   Scheduled Tasks
+-   Scheduled triggers
 -   Message Processors
 -   Polling Inbound Endpoints
 -   Event-Based Inbound Endpoints
@@ -299,7 +299,7 @@ You could observe the following member removal log in other servers when one nod
 
 ##  Testing task coordination
 
-Create a simple scheduled task using WSO2 Integration Studio and deploy it in the two WSO2 Integrator: MI servers. See the instructions on [creating a scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
+Create a simple scheduled task using WSO2 Integration Studio and deploy it in the two WSO2 Integrator: MI servers. See the instructions on [creating a scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -49,7 +49,7 @@ Most of the integration solutions that you develop can be deployed using a singl
 
 However, the following integration artifacts are **stateful** and require coordination when deployed across multiple WSO2 Integrator: MI instances.
 
--   Scheduled Tasks
+-   Scheduled triggers
 -   Message Processors
 -   Polling Inbound Endpoints
     -   File Inbound Endpoint

--- a/en/docs/learn/examples/jms-examples/detecting-repeatedly-redelivered-messages.md
+++ b/en/docs/learn/examples/jms-examples/detecting-repeatedly-redelivered-messages.md
@@ -106,7 +106,7 @@ See the descriptions of the above configurations:
 Create the artifacts:
 
 {!includes/build-and-run.md!}
-3. Create the [inbound endpoint]({{base_path}}/develop/creating-artifacts/creating-an-inbound-endpoint), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
+3. Create the [inbound endpoint]({{base_path}}/develop/creating-artifacts/creating-an-inbound-endpoint), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 
 Set up the broker:

--- a/en/docs/learn/examples/jms-examples/shared-topic-subscription.md
+++ b/en/docs/learn/examples/jms-examples/shared-topic-subscription.md
@@ -97,7 +97,7 @@ See the descriptions of the above configurations:
 Create the artifacts:
 
 {!includes/build-and-run.md!}
-3. Create the [proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
+3. Create the [proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 
 Set up the broker:

--- a/en/docs/learn/examples/jms-examples/specifying-a-delivery-delay-on-messages.md
+++ b/en/docs/learn/examples/jms-examples/specifying-a-delivery-delay-on-messages.md
@@ -135,7 +135,7 @@ See the descriptions of the above configurations:
 Create the artifacts:
 
 {!includes/build-and-run.md!}
-3. Create the [proxy services]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
+3. Create the [proxy services]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [registry artifact]({{base_path}}/develop/creating-artifacts/creating-registry-resources), [scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task), and [sequences]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences) with the configurations given above.
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 
 Set up the broker:

--- a/en/docs/learn/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
+++ b/en/docs/learn/examples/scheduled-tasks/injecting-messages-to-rest-endpoint.md
@@ -5,7 +5,7 @@ In order to use the Message Injector to inject messages to a RESTful endpoint, y
 
 Following are the integration artifacts that we can used to implement this scenario. See the instructions on how to [build and run](#build-and-run) this example.
 
-=== "Scheduled Task"
+=== "Scheduled trigger"
     ```xml
     <task class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz" name="SampleInjectToProxyTask" xmlns="http://ws.apache.org/ns/synapse">
         <trigger count="2" interval="5"/>
@@ -55,7 +55,7 @@ Following are the integration artifacts that we can used to implement this scena
 Create the artifacts:
 
 {!includes/build-and-run.md!}
-3. Create the [proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [endpoint]({{base_path}}/develop/creating-artifacts/creating-endpoint-templates), and a [scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
+3. Create the [proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service), [endpoint]({{base_path}}/develop/creating-artifacts/creating-endpoint-templates), and a [scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 
 The XML message you injected (i.e., This is a scheduled task of the default implementation.) will be printed in the logs of the WSO2 Integrator: MI twice, 5 seconds apart.

--- a/en/docs/learn/examples/scheduled-tasks/task-scheduling-simple-trigger.md
+++ b/en/docs/learn/examples/scheduled-tasks/task-scheduling-simple-trigger.md
@@ -5,7 +5,7 @@ This example demonstrates the concept of tasks and how a simple trigger works. H
 
 Following are the integration artifacts that we can used to implement this scenario. See the instructions on how to [build and run](#build-and-run) this example.
 
-=== "Scheduled Task"
+=== "Scheduled trigger"
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>
     <task class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz" name="CheckPrice" xmlns="http://ws.apache.org/ns/synapse">
@@ -56,7 +56,7 @@ Following are the integration artifacts that we can used to implement this scena
 Create the artifacts:
 
 {!includes/build-and-run.md!}
-3. Create the [main sequence]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences), [endpoint]({{base_path}}/develop/creating-artifacts/creating-endpoint-templates), and a [scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
+3. Create the [main sequence]({{base_path}}/develop/creating-artifacts/creating-reusable-sequences), [endpoint]({{base_path}}/develop/creating-artifacts/creating-endpoint-templates), and a [scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task) with the configurations given above.
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 
 Set up the back-end service:

--- a/en/docs/learn/integration-tutorials/using-scheduled-tasks.md
+++ b/en/docs/learn/integration-tutorials/using-scheduled-tasks.md
@@ -9,7 +9,7 @@ The sections below demonstrate an example of a scheduled trigger (task) that inj
 - [Sequence]({{base_path}}/reference/mediation-sequences)
 - [Log Mediator]({{base_path}}/reference/mediators/log-mediator)
 - [Drop Mediator]({{base_path}}/reference/mediators/drop-mediator)
-- [Scheduled Task]({{base_path}}/reference/synapse-properties/scheduled-task-properties)
+- [Scheduled trigger]({{base_path}}/reference/synapse-properties/scheduled-task-properties)
 
 ## Let's get started!
 

--- a/en/docs/learn/integration-use-case/scheduled-task-overview.md
+++ b/en/docs/learn/integration-use-case/scheduled-task-overview.md
@@ -2,7 +2,7 @@
 
 Executing an integration process at a specified time is another common requirement in enterprise integration. For example, in an organization, there can be a need for running an integration process to synchronize two systems every day at the day end.  
 
-In WSO2 Integrator: MI, execution of a message mediation process can be automated to run periodically by using a 'Scheduled task'. You can schedule a task to run in the time interval of 't' for 'n' number of times or to run once the WSO2 Integrator: MI starts. 
+In WSO2 Integrator: MI, execution of a message mediation process can be automated to run periodically by using a 'Scheduled trigger'. You can schedule a task to run in the time interval of 't' for 'n' number of times or to run once the WSO2 Integrator: MI starts. 
 
 Furthermore, you can use cron expressions for more advanced executing time configuration.
 

--- a/en/docs/learn/learn-overview.md
+++ b/en/docs/learn/learn-overview.md
@@ -286,7 +286,7 @@ Learn how to implement various integration use cases, deploy them in the WSO2 In
                         <li><a href="{{base_path}}/learn/examples/inbound-endpoint-examples/inbound-endpoint-with-registry">How to use an Inbound Endpoints with Registry</a></li>
                     </ul>
                 </li>
-                <li>Scheduled Tasks 
+                <li>Scheduled triggers 
                     <ul>
                         <li><a href="{{base_path}}/learn/examples/scheduled-tasks/task-scheduling-simple-trigger">How to schedule tasks using a simple trigger</a></li>
                         <li><a href="{{base_path}}/learn/examples/scheduled-tasks/injecting-messages-to-rest-endpoint">How to inject messages to a RESTful endpoint</a></li>

--- a/en/docs/learn/samples/periodical-scheduled-tasks.md
+++ b/en/docs/learn/samples/periodical-scheduled-tasks.md
@@ -1,16 +1,16 @@
-# Periodical Scheduled Tasks Sample
+# Periodical Scheduled triggers Sample
 
 This sample demonstrates the task scheduling capabilities of the WSO2 Integrator: MI.
 
 The scenario is about fetching information related to personal records from a service periodically.
 
-This sample consists of a Scheduled Task called `PersonRecordRetrieveTask`, an Endpoint called `PersonRecordEP`, and a Sequence called `PersonRecordSeq`.
+This sample consists of a Scheduled trigger called `PersonRecordRetrieveTask`, an Endpoint called `PersonRecordEP`, and a Sequence called `PersonRecordSeq`.
 
 The scheduled task is configured to run five times in 30 seconds time intervals. It injects messages to the sequence and the sequence invokes the endpoint to get the person record.
 
 ## Deploying the sample
 
-1.  Open the sample by clicking on the **Periodical Scheduled Tasks** card.
+1.  Open the sample by clicking on the **Periodical Scheduled triggers** card.
 2.  Give a folder location to save the sample.
 3.  [Build and run]({{base_path}}/develop/deploy-artifacts#build-and-run) the sample in your WSO2 Integrator: MI.
 

--- a/en/docs/observe-and-manage/managing-integrations-with-micli.md
+++ b/en/docs/observe-and-manage/managing-integrations-with-micli.md
@@ -1297,9 +1297,9 @@ Follow the instructions below to display a list of artifacts or get information 
         Mediators - LogMediator, STRING
         ```
 
-### Scheduled Tasks
+### Scheduled triggers
 
-1.  List scheduled tasks in an environment.
+1.  List scheduled triggers in an environment.
 
     -   **Command**
         ``` bash
@@ -1327,7 +1327,7 @@ Follow the instructions below to display a list of artifacts or get information 
         CheckPriceTask
         ```
 
-2.  Get information on a specific scheduled task in an environment.
+2.  Get information on a specific scheduled trigger in an environment.
 
     -   **Command**
         ``` bash

--- a/en/docs/reference/synapse-properties/scheduled-task-properties.md
+++ b/en/docs/reference/synapse-properties/scheduled-task-properties.md
@@ -1,4 +1,4 @@
-# Scheduled Tasks
+# Scheduled triggers
 ## Introduction
 
 WSO2 Integrator: MI can be configured to execute tasks periodically. According to the default task scheduling implementation in WSO2 Integrator: MI, a task can be configured to inject messages, either to a defined endpoint, to a proxy service, or a specific sequence. If required, you can use a custom task scheduling implementation.
@@ -17,11 +17,11 @@ You can schedule a task to run after a time interval of 't' for an 'n' number of
 
 ## Properties
 
-See the topics given below for the list of properties that can be configured when you [create a Scheduled Task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
+See the topics given below for the list of properties that can be configured when you [create a Scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
 
 ### Required Properties
 
-The following properties are required when [creating a scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
+The following properties are required when [creating a scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
 
 <table>
    <thead>
@@ -125,7 +125,7 @@ The following properties are required when [creating a scheduled task]({{base_pa
 
 ### Task Implementation Properties
 
-Listed below are the optional task implementation properties you can use when [creating a scheduled task]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
+Listed below are the optional task implementation properties you can use when [creating a scheduled trigger]({{base_path}}/develop/creating-artifacts/creating-scheduled-task).
 
 <table>
    <thead>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -218,7 +218,7 @@ nav:
               - Create a REST API: develop/creating-artifacts/creating-an-api.md
               - Create a Proxy Service: develop/creating-artifacts/creating-a-proxy-service.md
               - Create an Inbound Endpoint: develop/creating-artifacts/creating-an-inbound-endpoint.md
-              - Create Scheduled Tasks: develop/creating-artifacts/creating-scheduled-task.md
+              - Create Scheduled triggers: develop/creating-artifacts/creating-scheduled-task.md
               - Create a Message Store: develop/creating-artifacts/creating-a-message-store.md
               - Create a Message Processor: develop/creating-artifacts/creating-a-message-processor.md
               - Create an Endpoint: develop/creating-artifacts/creating-endpoints.md
@@ -443,7 +443,7 @@ nav:
          # - JSON to XML Mapping: learn/samples/
           - Kafka Consumer and Producer: learn/samples/kafka-sample.md
           - Message Filtering: learn/samples/message-filtering.md
-          - Periodical Scheduled Tasks: learn/samples/periodical-scheduled-tasks.md
+          - Periodical Scheduled triggers: learn/samples/periodical-scheduled-tasks.md
           - Protocol Switching: learn/samples/protocol-switching.md
           - Proxying a REST Service: learn/samples/proxying-rest-service.md
           - Proxying a SOAP Service: learn/samples/proxying-soap-service.md
@@ -983,7 +983,7 @@ nav:
       - Scopes: reference/synapse-properties/scopes.md
       - Templates: reference/synapse-properties/template-properties.md
       - Mediation Sequences: reference/mediation-sequences.md
-      - Scheduled Task Properties: reference/synapse-properties/scheduled-task-properties.md
+      - Scheduled trigger Properties: reference/synapse-properties/scheduled-task-properties.md
       - Message Stores and Processors:
           - About Message Stores and Processors: reference/synapse-properties/about-message-stores-processors.md
           - Message Stores:


### PR DESCRIPTION
This pull request updates the documentation to consistently refer to "Scheduled triggers" instead of "Scheduled Tasks" throughout the WSO2 Integrator: MI docs. The changes improve clarity and maintain uniform terminology across guides, tutorials, examples, and references.

Terminology updates across documentation:

* Renamed "Scheduled Task" to "Scheduled trigger" in all relevant documentation sections, including guides, tutorials, and sample descriptions [[1]](diffhunk://#diff-226aac134bd12cb96b830042d9d4e0b59e14725ea186539c48843c508c57b556L1-R11) [[2]](diffhunk://#diff-3ec87a5f9665368a4ede50a5c401e1ff049ac11d4e82a6be0cdd84ca2d6fe9a1L1-R13) [[3]](diffhunk://#diff-29dfefb753c3bc6233f46fef07cd82feadb4fd8c58e06db87acf5cbd99d5f9ccL289-R289) [[4]](diffhunk://#diff-6b7352254710ee349a1d9ae0e65bfb9d1403fe44d1d3a500cae5f4efbc0066aeL96-R100) [[5]](diffhunk://#diff-3934f90d23ed547dda0dee46c37ff5c8181dfaea024650291c8fd1da0d222dabL5-R5).
* Updated references and links to use "Scheduled trigger" in navigation, property catalogs, and integration concepts [[1]](diffhunk://#diff-bad796a5817360afc5105769cce9543a6fc6859c0f203202af1f0d96fefe42beL75-R75) [[2]](diffhunk://#diff-bad796a5817360afc5105769cce9543a6fc6859c0f203202af1f0d96fefe42beL138-R138) [[3]](diffhunk://#diff-226aac134bd12cb96b830042d9d4e0b59e14725ea186539c48843c508c57b556L49-R49) [[4]](diffhunk://#diff-8b3d04954da20f986a66bcdb65d6a29b5ee03f3b043903b715fa7e182ab1cc12L12-R12).
* Changed example and sample artifact instructions to use "Scheduled trigger" terminology, including code blocks, artifact creation steps, and sample cards [[1]](diffhunk://#diff-f96232c5dd62b5c8c5db334196cc818fbb5727abda4488864e1f8e2b7d16195eL8-R8) [[2]](diffhunk://#diff-f96232c5dd62b5c8c5db334196cc818fbb5727abda4488864e1f8e2b7d16195eL58-R58) [[3]](diffhunk://#diff-4007b0270be5aebe0a2e15de54a11e531d2d18defb1368de63d2010ee0e151dbL8-R8) [[4]](diffhunk://#diff-4007b0270be5aebe0a2e15de54a11e531d2d18defb1368de63d2010ee0e151dbL59-R59) [[5]](diffhunk://#diff-391dc8df629508154c749d16343f0ce29277dd8eafd7341e547d9f0fdb96251fL100-R100) [[6]](diffhunk://#diff-5f40f7c3b6c98bd7f3af46ce8146ef17d5c0ac3014600d62bc6e02cc59db1342L138-R138) [[7]](diffhunk://#diff-00ef9214168718dfa4be542606ffa9a96518a0fb0551f86c212bcec50e594796L109-R109) [[8]](diffhunk://#diff-ab2abb2049d02c1fa94b9da4a2269cf4edb76f3b50028b007788c1496e6ee8b0L320-R320).
* Updated deployment and coordination documentation to reflect the new terminology for stateful artifacts [[1]](diffhunk://#diff-90deee8f2801383b951df4bcececf6ed564724c9eaa8ddf91679e33231f1f9bfL45-R45) [[2]](diffhunk://#diff-90deee8f2801383b951df4bcececf6ed564724c9eaa8ddf91679e33231f1f9bfL302-R302) [[3]](diffhunk://#diff-dc458c99749ba726bfc506ae99a67e8778fcce1fa9dc462d02997398529d1ed5L52-R52) [[4]](diffhunk://#diff-b0c599acd80ed065f9fd267d6d06c21e358b99827a1a75a31dad10117990521dL290-R290).
* Modified CLI management documentation to list and describe "Scheduled triggers" instead of "Scheduled Tasks" [[1]](diffhunk://#diff-2a323dfb5f157a1edfdac063b6e453993ca42dfc3211b10f8f79716ed9c88366L1300-R1302) [[2]](diffhunk://#diff-2a323dfb5f157a1edfdac063b6e453993ca42dfc3211b10f8f79716ed9c88366L1330-R1330).

These changes ensure consistency and help users better understand and work with scheduled integration artifacts in WSO2 Integrator: MI.