### PR TITLE
Update Jolokia agent version in JMX monitoring documentation

### DIFF
--- a/en/docs/observe-and-manage/classic-observability-metrics/jmx-monitoring.md
+++ b/en/docs/observe-and-manage/classic-observability-metrics/jmx-monitoring.md
@@ -67,12 +67,12 @@ Follow the steps below to use Jolokia to monitor a WSO2 product using a JVM Agen
 It can be dynamically attached (and
 detached) to an already running Java process. This universal agent uses the JVM agent API and is available for every Sun/Oracle JVM 1.6 and later.
 
-1. Download [JVM-Agent](https://jolokia.org/download.html). (These instructions are tested with the Jolokia JVM-Agent version 1.7.1 by downloading the `jolokia-jvm-1.7.1.jar` file.)
+1. Download the [JVM-Agent](https://jolokia.org/download.html) (version 2.4.0).
 2. Add it to the `<MI_HOME>/dropins/` directory.
 3. Start the WSO2 product server.
-4. Get the PID of wso2 server
-5. Start the JVM Agent ex: java -jar jolokia-jvm-1.7.1.jar --host=localhost --port=9764 start <PID>
-6. Also you can call it with --help to get a short usage information:
+4. Get the PID of the WSO2 server.
+5. Start the JVM Agent. Example: java -jar jolokia-jvm-2.4.0-agent.jar start <PID> --host localhost --port 9763
+6. You can call it with --help to get usage information: java -jar jolokia-jvm-2.4.0-agent.jar --help
 
    Once the server starts, you can read MBeans using Jolokia APIs. The following are a few examples.
 
@@ -86,7 +86,7 @@ detached) to an already running Java process. This universal agent uses the JVM 
 
 Follow the steps below to use Jolokia to monitor a WSO2 product using OSGi Agent.
 
-1. Download [Osgi-Agent (full bundle)](https://jolokia.org/download.html). (These instructions are tested with the Jolokia OSGI Agent version 1.7.1 by downloading the `jolokia-osgi-bundle-1.7.1.jar` file.)
+1. Download the [Osgi-Agent (full bundle)](https://jolokia.org/download.html) (version 2.4.0).
 2. Add it to the `<MI_HOME>/dropins/` directory.
 3. Start the WSO2 product server.
 4. You can define the port with system variables. E.g., `./micro-integrator.sh -Dorg.osgi.service.http.port=9763`


### PR DESCRIPTION
This pull request updates the documentation for monitoring WSO2 products with Jolokia by switching instructions to use Jolokia version 2.4.0 instead of 1.7.1. The steps and example commands have been updated to match the newer version, ensuring users follow the latest and most secure practices.

**Documentation updates for Jolokia version:**

* Updated the JVM Agent monitoring instructions to use Jolokia version 2.4.0, including download links and example commands for starting the agent and accessing help information.
* Updated the OSGi Agent monitoring instructions to reference Jolokia version 2.4.0, including the download link.