### PR TITLE
Remove json-eval() from JSON expression examples

### DIFF
--- a/en/docs/learn/examples/json-examples/json-examples.md
+++ b/en/docs/learn/examples/json-examples/json-examples.md
@@ -375,7 +375,7 @@ You can use JSON path expressions with following mediators:
 <div class="code panel pdl" style="border-width: 1px;">
 <div class="codeContent panelContent pdl">
 <pre class="html/xml" data-syntaxhighlighter-params="brush: html/xml; gutter: false; theme: Confluence" data-theme="Confluence" style="brush: html/xml; gutter: false; theme: Confluence"><code>&lt;property name=&quot;location&quot; 
-              expression=&quot;json-eval($.coordinates.location[0].name)&quot;/&gt;</code></pre>
+              expression=&quot;$.coordinates.location[0].name&quot;/&gt;</code></pre>
 </div>
 </div>
 </div></td>

--- a/en/docs/reference/mediators/property-mediator.md
+++ b/en/docs/reference/mediators/property-mediator.md
@@ -85,7 +85,7 @@ The parameters available to configure the property mediator are as follows:
 
   Example 2 : Creating a property with a JSON object via expression evaluation.</br>
 
-  <code>&lt;property name="studentObject" expression="json-eval($.student)" type="JSON"/&gt;</code>
+  <code>&lt;property name="studentObject" expression="$.student" type="JSON"/&gt;</code>
 
 </p>
 </div>


### PR DESCRIPTION
# PR: Fix Property Mediator Documentation for MI 4.4.0 JSONPath Syntax

## Purpose
Remove deprecated `json-eval()` wrapper from Property Mediator documentation to reflect the correct JSONPath syntax in MI 4.4.0. Resolves documentation inconsistency with actual runtime behavior.

## Goals
- Update Property Mediator documentation to show correct JSONPath expression syntax  
- Remove deprecated `json-eval()` wrapper from examples  
- Prevent errors users may encounter when using the old syntax  

## Approach
- Update example code snippets in Property Mediator documentation to use direct JSONPath syntax  
- Update related JSON examples to use correct syntax  
- Remove references to `json-eval()` function  

## User Stories
- **As a MI 4.4.0 developer**, I want to correctly use JSONPath expressions in Property Mediator without encountering errors  
- **As a developer migrating to MI 4.4.0**, I need clear documentation about JSONPath syntax changes  

## Release Note
Updated Property Mediator documentation to reflect correct JSONPath expression syntax in MI 4.4.0. The `json-eval()` wrapper is no longer required when using JSONPath expressions.

## Documentation
**Affected files:**  
- `property-mediator.md`  
- `json-examples.md`

## Training
N/A - Documentation only change  

## Certification
N/A - Documentation update only, no functional changes  

## Marketing
N/A - Technical documentation update  

## Automation Tests
N/A - Documentation only  

## Security Checks
- Followed secure coding standards: N/A (doc only)  
- Ran FindSecurityBugs plugin: N/A (doc only)  
- No secrets committed

## Samples
Updated examples show correct JSONPath syntax:  
```xml
<property name="studentObject" expression="$.student" type="JSON"/>
```

(Updated mediator examples use $.student directly, without json-eval().)

## Related PRs

None

## Migrations

Developers need to update existing mediator configurations to remove json-eval() wrapper when using JSONPath expressions in MI 4.4.0

## Test Environment

N/A - Documentation change only

## Learning

- Reviewed MI 4.4.0 runtime behavior
- Tested JSONPath expressions in MI 4.4.0
- Verified error messages when using deprecated syntax