### PR TITLE
Update syntax highlighting (Closes #1485 )

### DIFF
--- a/en/docs/assets/lib/highlightjs/styles/custom-highlight-styles.css
+++ b/en/docs/assets/lib/highlightjs/styles/custom-highlight-styles.css
@@ -1,0 +1,131 @@
+
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+  border-radius: 6px;
+}
+code.hljs {
+  padding: 3px 5px;
+  border-radius: 4px;
+}
+
+[data-md-color-scheme="default"] .hljs {
+  background: #ffffff;
+  color: #000000;
+}
+
+[data-md-color-scheme="default"] .hljs-comment,
+[data-md-color-scheme="default"] .hljs-quote {
+  color: #008000; 
+  font-style: italic;
+}
+
+[data-md-color-scheme="default"] .hljs-keyword,
+[data-md-color-scheme="default"] .hljs-selector-tag,
+[data-md-color-scheme="default"] .hljs-built_in,
+[data-md-color-scheme="default"] .hljs-name,
+[data-md-color-scheme="default"] .hljs-tag {
+  color: #0777d3; 
+}
+
+[data-md-color-scheme="default"] .hljs-string,
+[data-md-color-scheme="default"] .hljs-template-variable,
+[data-md-color-scheme="default"] .hljs-title,
+[data-md-color-scheme="default"] .hljs-type {
+  color: #a31515;
+}
+
+[data-md-color-scheme="default"] .hljs-attr {
+  color: #aa5500; 
+}
+
+[data-md-color-scheme="default"] .hljs-number,
+[data-md-color-scheme="default"] .hljs-literal,
+[data-md-color-scheme="default"] .hljs-variable {
+  color: #2b91af; 
+}
+
+[data-md-color-scheme="default"] .hljs-function,
+[data-md-color-scheme="default"] .hljs-title.function_ {
+  color: #795e26; 
+}
+
+
+[data-md-color-scheme="default"] .hljs-bullet,
+[data-md-color-scheme="default"] .hljs-link,
+[data-md-color-scheme="default"] .hljs-symbol {
+  color: #00b0e8;
+  text-decoration: underline;
+}
+
+
+[data-md-color-scheme="default"] .hljs-emphasis {
+  font-style: italic;
+}
+[data-md-color-scheme="default"] .hljs-strong {
+  font-weight: 700;
+}
+
+/* Dark theme - Slate */
+
+[data-md-color-scheme="slate"] .hljs {
+  background: #1e1e1e;
+  color: #dcdcdc;
+}
+
+
+[data-md-color-scheme="slate"] .hljs-comment,
+[data-md-color-scheme="slate"] .hljs-quote {
+  color: #6a9955;
+  font-style: italic;
+}
+
+
+[data-md-color-scheme="slate"] .hljs-keyword,
+[data-md-color-scheme="slate"] .hljs-selector-tag,
+[data-md-color-scheme="slate"] .hljs-built_in,
+[data-md-color-scheme="slate"] .hljs-name,
+[data-md-color-scheme="slate"] .hljs-tag {
+  color: #569cd6;
+}
+
+
+[data-md-color-scheme="slate"] .hljs-string,
+[data-md-color-scheme="slate"] .hljs-template-variable {
+  color: #ce9178; 
+}
+
+
+[data-md-color-scheme="slate"] .hljs-attr {
+  color: #d7ba7d; 
+}
+
+
+[data-md-color-scheme="slate"] .hljs-number,
+[data-md-color-scheme="slate"] .hljs-literal,
+[data-md-color-scheme="slate"] .hljs-variable {
+  color: #b5cea8; 
+}
+
+
+[data-md-color-scheme="slate"] .hljs-function,
+[data-md-color-scheme="slate"] .hljs-title.function_ {
+  color: #dcdcaa; 
+}
+
+
+[data-md-color-scheme="slate"] .hljs-bullet,
+[data-md-color-scheme="slate"] .hljs-link,
+[data-md-color-scheme="slate"] .hljs-symbol {
+  color: #4fc1ff; 
+  text-decoration: underline;
+}
+
+
+[data-md-color-scheme="slate"] .hljs-emphasis {
+  font-style: italic;
+}
+[data-md-color-scheme="slate"] .hljs-strong {
+  font-weight: bold;
+}

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1176,7 +1176,8 @@ plugins:
 extra_css:
   # You can select a different theme for syntax highlighting by simply
   # selecting a different css file file bellow from the available list.
-  - assets/lib/highlightjs/styles/vs.min.css
+  # assets/lib/highlightjs/styles/vs.min.css
+  - assets/lib/highlightjs/styles/custom-highlight-styles.css
   # Make sure to activate only one palette at a time.
   # If all the palettes are commented out, the default material theme palette will take over
   - assets/css/blue-palette-alt1.css


### PR DESCRIPTION
## Purpose
> The current syntax highlighting for code blocks in the documentation has low contrast and lacks distinct highlighting for attributes, values, and tags. This makes it harder for users to quickly scan and understand examples.

## Goals
> Improve readability and better visual distinction 

## Approach
> created a custom syntax highlight .css file with different color sets for light and dark themes

## User stories
> This is done as a part of the WSO2 hacktoberfest 2025

## Release note
> Improved syntax highlighting for better readability in code blocks.

## Documentation
> This PR directly updates the documentation site styling. No separate doc impact

## Training
> N/A

## Certification
> N/A – No impact on certification exams. Just syntax highlight update 

## Marketing
> N/A – This is a developer documentation improvement, not a feature release.

## Automation tests
 - Unit tests 
   > N/A (only a style change) 
 - Integration tests
   >Verified visually by running the MkDocs server locally.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A – No new product samples introduced.

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
>OS : Win 11 64bit
>Python version : 3.10 
>Tested executing mkdocs serve locally

 
## Learning
>Reviewed python markdown docs