### PR TITLE
Add documentation about restrict accessing to java classes and methods in script mediator for 4.3.0

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -239,6 +239,63 @@ Given below are the security guidelines for the Micro Integrator runtime.
             <p><strong>Tip</strong>: To run the JVM with 2 GB (-Xmx2048m), you should ideally have about 4GB of memory on the physical machine.</p>
          </td>
       </tr>
+      <tr class="even">
+         <td>
+            <p>Restrict Access to Java classes and Java Methods/Native Objects in Scripts</p>
+            <p><br /></p>
+         </td>
+         <td>
+            <p>
+               JS scripts can be used inside script mediators (eg: in Mock Endpoints) to access Java classes,
+               methods, and native objects. By default, all the classes are visible to these scripts.
+               However, it is recommended to restrict access to these.
+            </p>
+            <p>
+               <b>Limiting Access to Java Classes</b><br />
+               Access to Java Classes can be restricted by providing the following configurations
+               in <code>deployment.toml</code>.
+            </p>
+            <pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence"
+               data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>[synapse_properties]
+'limit_java_class_access_in_scripts.enable' = true # or false
+'limit_java_class_access_in_scripts.list_type' = "ALLOW_LIST" # or BLOCK_LIST
+'limit_java_class_access_in_scripts.class_prefixes' = "java.util"</code></pre>
+            <p>
+               Only the Java classes having names starting with any of the values given under
+               <code>limit_java_class_access_in_scripts.class_prefixes</code> will be allowed,
+               when <code>limit_java_class_access_in_scripts.list_type</code> is <code>ALLOW_LIST</code>
+               (all other classes will not be allowed).<br />
+               Likewise, when <code>limit_java_class_access_in_scripts.list_type</code> is <code>BLOCK_LIST</code>,
+               classes with matching names will be selectively blocked. 
+            </p>
+            <div style="background:#f8f9fa; border-left:4px solid #ccc; padding:8px; margin:8px 0;">
+               <strong>Note:</strong>  
+               Limiting access to Java classes is supported with Rhino JS, Nashorn JS, and GraalJS engines.
+            </div>
+            <p>
+               <b>Limiting Access to Java Methods/Native Objects</b><br />
+               Access to Java Methods/Native Objects can be restricted by providing the following
+               configurations in <code>deployment.toml</code>.
+            </p>
+            <pre class="java" data-syntaxhighlighter-params="brush: java; gutter: false; theme: Confluence"
+               data-theme="Confluence" style="brush: java; gutter: false; theme: Confluence"><code>[synapse_properties]
+'limit_java_native_object_access_in_scripts.enable' = true # or false
+'limit_java_native_object_access_in_scripts.list_type' = "BLOCK_LIST" # Or "ALLOW_LIST"
+'limit_java_native_object_access_in_scripts.object_names' = "getClassLoader"</code></pre>
+            <p>
+               Java methods/native objects having names equal to any of the values given under
+               <code>limit_java_native_object_access_in_scripts.object_names</code>, will be selectively
+               blocked when <code>limit_java_native_object_access_in_scripts.list_type</code> is
+               <code>BLOCK_LIST</code> (all other methods will be allowed).<br />
+               Likewise, when <code>limit_java_native_object_access_in_scripts.list_type</code>
+               is <code>ALLOW_LIST</code>, methods with matching names will be selectively allowed.
+            </p>
+            <div style="background:#f8f9fa; border-left:4px solid #ccc; padding:8px; margin:8px 0;">
+               <strong>Note:</strong>  
+               Limiting access to Java methods is only supported with the Rhino JS engine.
+            </div>
+         </td>
+      </tr>
    </tbody>
 </table>
 


### PR DESCRIPTION
## Purpose
Add a new guideline on restricting access to java classes and java methods/native objects in scripts that are used in script mediator.

The updated section will appear as below.
<img width="930" height="597" alt="Screenshot 2025-10-02 at 10 57 12" src="https://github.com/user-attachments/assets/1c0d4fe0-388b-4d59-ae1f-7b5bf5c3d438" />
