### PR TITLE
Add documentation about restrict accessing to java classes and methods in script mediator

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -246,7 +246,7 @@ Given below are the security guidelines for the WSO2 Integrator: MI runtime.
          </td>
          <td>
             <p>
-               JS scripts can be used inside script mediators (e.g., in Mock Endpoints) to access Java classes,
+               JS scripts can be used inside script mediators to access Java classes,
                methods, and native objects. From MI 4.5.0 onward, access to the classes <code>java.lang</code>, <code>java.io</code>, <code>java.nio</code>, and <code>java.net</code> from the script mediator is revoked by default. If existing script mediator use cases rely on these classes, either
                   <ol>
                      <li>Modify the existing integration artifacts accordingly or</li>

--- a/en/docs/reference/mediators/script-mediator.md
+++ b/en/docs/reference/mediators/script-mediator.md
@@ -84,7 +84,7 @@ JavaScript, Groovy, or Ruby.
 
     !!! Note
          - The `nashornJs` language is deprecated in JDK 15 and above. If you are using JDK 15 or above, you need to manually copy the [nashorn-core](https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core/15.4) and [asm-util](https://mvnrepository.com/artifact/org.ow2.asm/asm-util/9.5) JAR files to the <code>&lt;MI_HOME&gt;/lib</code> directory since Nashorn was [removed](https://openjdk.org/jeps/372) from the JDK.
-         - From MI 4.5.0 onward, access to the classes <code>java.lang</code>, <code>java.io</code>, <code>java.nio</code>, and <code>java.net</code> from the script mediator is revoked by default. Refer to the [Security Guideline](https://mi.docs.wso2.com/en/4.5.0/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment) for more information.
+         - From MI 4.5.0 onward, access to the classes <code>java.lang</code>, <code>java.io</code>, <code>java.nio</code>, and <code>java.net</code> from the script mediator is revoked by default. For more details, see the [Security Guidelines]({{base_path}}/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment).
 
 ## Syntax
 


### PR DESCRIPTION
## Purpose
Add a new guideline on restricting access to java classes and java methods/native objects in scripts that are used in script mediator.

The updated section in security guide lines page will appear as below.
<img width="993" height="591" alt="Screenshot 2025-10-09 at 11 47 18" src="https://github.com/user-attachments/assets/c815e7a5-fd1f-45ef-915f-8f9ec31cbff6" />

The updated section in the script mediator page will appear as below.
<img width="958" height="565" alt="Screenshot 2025-10-09 at 11 52 28" src="https://github.com/user-attachments/assets/e547434d-f5c1-4b31-bb6e-b43ab66e4664" />


