### PR TITLE
Revert "Fix: Update ActiveMQ supported version documentation [4.3.0]"

### DIFF
--- a/en/docs/install-and-setup/setup/brokers/configure-with-activemq.md
+++ b/en/docs/install-and-setup/setup/brokers/configure-with-activemq.md
@@ -6,7 +6,7 @@ This section describes how to configure WSO2 Micro Integrator to connect with Ac
 
 Follow the instructions below to set up and configure.
 
-1.  Download [Apache ActiveMQ](http://activemq.apache.org/). Micro Integrator supports ActiveMQ Classic versions up to 6.1.x.
+1.  Download [Apache ActiveMQ](http://activemq.apache.org/). Micro Integrator supports ActiveMQ Classic versions up to 5.18.x.
 2.  Download and install WSO2 Micro Integrator.
 3.  Copy the following client libraries from the `ACTIVEMQ_HOME/lib` directory to the `MI_HOME/lib` directory.
 


### PR DESCRIPTION
Reverts wso2/docs-mi#1799 since ActiveMQ 6.1.x is not supported in MI 4.3.0