### PR TITLE
Change HTTP Endpoint code from 'URI' to 'uri-template'

### DIFF
--- a/en/docs/develop/externalized-configuration.md
+++ b/en/docs/develop/externalized-configuration.md
@@ -161,7 +161,7 @@ Listed below are the Endpoint parameters that can be dynamically injected.
     </tr>
     <tr>
         <td>HTTP Endpoint</td>
-        <td><code>URI</code></td>
+        <td><code>uri-template</code></td>
     </tr>
     <tr>
         <td>Template Endpoint</td>


### PR DESCRIPTION
Updated 'HTTP Endpoint' code representation from 'URI' to 'uri-template'.
