### PR TITLE
Update MI versions with 4.5.0

### DIFF
--- a/en/docs/assets/versions.json
+++ b/en/docs/assets/versions.json
@@ -1,15 +1,20 @@
 {
-  "4.4.0": "main",
-  "current": "4.4.0",
+  "4.5.0": "main",
+  "current": "4.5.0",
   "list": [
+    "4.5.0",
     "4.4.0",
     "4.3.0",
     "4.2.0"
    ],
   "all": {
-    "4.4.0":{
+    "4.5.0":{
         "doc": "latest",
         "notes": "latest/get-started/about-this-release"
+    },
+    "4.4.0":{
+      "doc": "https://mi.docs.wso2.com/en/4.4.0/",
+      "notes": "https://mi.docs.wso2.com/en/4.4.0/get-started/about-this-release/"
     },
     "4.3.0":{
         "doc": "https://mi.docs.wso2.com/en/4.3.0/",


### PR DESCRIPTION
Sends https://github.com/wso2/docs-mi/pull/1835 again as it was reverted with https://github.com/wso2/docs-mi/pull/1836