### PR TITLE
Update docs for Prometheus client API upgrade

### DIFF
--- a/en/docs/observe-and-manage/setting-up-cloud-native-observability-on-a-vm.md
+++ b/en/docs/observe-and-manage/setting-up-cloud-native-observability-on-a-vm.md
@@ -118,6 +118,22 @@ After applying the above change, you can start the WSO2 Integrator: MI with the 
 -DenablePrometheusApi=true
 ```
 
+From WSO2 MI versions after 4.5.0, the new Prometheus client API version 1.x is enabled by default. You can switch back to the old client API 0.x using the following JVM property:
+```
+-DusePrometheusLegacyApi=true
+```
+
+Depending on the client API version you are going to use, you have to choose the matching Grafana dashboard revisions as follows.
+
+| Dashboard name                   | API version 1.x | API version 0.x | 
+|----------------------------------|-----------------|-----------------|
+| WSO2 API Metrics                 | Revision 3      | Revision 2      |
+| WSO2 Inbound Endpoint Metrics    | Revision 2      | Revision 1      |
+| WSO2 Integration Cluster Metrics | Revision 2      | Revision 1      |
+| WSO2 Integration Node Metrics    | Revision 3      | Revision 2      |
+| WSO2 Proxy Service Metrics       | Revision 2      | Revision 1      |
+
+
 ## Step 2 - Optionally, integrate the Log Processing add-on
 
 Once you have successfully set up the [minimum deployment](#step-1-set-up-the-minimum-deployment), you need to set up the log processing add-on to process logs. To achieve this, you can use Grafana Loki-based logging stack.


### PR DESCRIPTION
## Purpose
> Update docs for Prometheus client API upgrade
Related to wso2/product-micro-integrator/issues/4479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a configuration option to revert to the legacy Prometheus client API via a JVM property.
  * Introduced a Grafana dashboard revision mapping table that selects revisions per Prometheus API version (1.x vs 0.x).
  * Updated deployment guidance (Step 1.4) to align minimum deployment instructions with both Prometheus API versions and corresponding dashboards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->