### PR TITLE
Add support for enabling/disabling message statistics

### DIFF
--- a/en/docs/observe-and-manage/working-with-management-api.md
+++ b/en/docs/observe-and-manage/working-with-management-api.md
@@ -532,6 +532,30 @@ The management API has multiple resources to provide information regarding the d
         {"message":"Enabled tracing for ('HelloWorld')"}
 	    ```
 
+### ENABLE/DISABLE MESSAGE STATISTICS for PROXY SERVICES
+
+-	**Resource**: `/proxy-services`
+
+	**Description**: Enable or disable message statistics for a specified proxy service.
+
+	**Example**:
+    
+    === "Request"
+	    ```bash 
+	    	curl -X POST \
+        	  https://localhost:9164/management/proxy-services \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "HelloWorld",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response"        
+	    ```bash 
+        {"message":"Enabled statistics for ('HelloWorld')"}
+	    ```
+
 ### GET CARBON APPLICATIONS
 
 -	**Resource**: `/applications`
@@ -779,6 +803,29 @@ The management API has multiple resources to provide information regarding the d
 	    ```bash 
         {"message":"Enabled tracing for ('HTTPEP')"}
 	    ```
+
+### ENABLE/DISABLE MESSAGE STATISTICS for ENDPOINTS
+
+-	**Resource**: `/endpoints`
+
+	**Description**: Enable or disable message statistics for a specified endpoint.
+	**Example**:
+	
+    === "Request"
+        ```bash 
+	    	curl -X POST \
+        	  https://localhost:9164/management/endpoints \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "HTTPEP",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response"    
+	    ```bash 
+        {"message":"Enabled statistics for ('HTTPEP')"}
+	    ```
 	
 ### GET APIs
 
@@ -857,7 +904,30 @@ The management API has multiple resources to provide information regarding the d
 	    ```bash 
         {"message":"Enabled tracing for ('helloApi')"}
 	    ```
-	
+
+### ENABLE/DISABLE MESSAGE STATISTICS for APIs
+
+-	**Resource**: `/apis`
+
+	**Description**: Enable or disable message statistics for a specified API.
+	**Example**:
+    
+    === "Request"
+        ```bash 
+	    	curl -X POST \
+        	  https://localhost:9164/management/apis \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "helloApi",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response"
+	    ```bash 
+        {"message":"Enabled statistics for ('helloApi')"}
+	    ```
+
 ### GET SEQUENCES
 
 -	**Resource**: `/sequences`
@@ -950,6 +1020,30 @@ The management API has multiple resources to provide information regarding the d
         {"message":"Enabled tracing for ('helloSequence')"}
 	    ```
 	
+
+### ENABLE/DISABLE MESSAGE STATISTICS for SEQUENCES
+
+-	**Resource**: `/sequences`
+
+	**Description**: Enable or disable message statistics for a specified sequence.
+	**Example**:
+    
+    === "Request"
+        ```bash  
+	    	curl -X POST \
+        	  https://localhost:9164/management/sequences \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "helloSequence",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response" 
+	    ```bash  
+        {"message":"Enabled statistics for ('helloSequence')"}
+	    ```
+
 ### GET LOCAL ENTRIES
 
 -	**Resource**: `/local-entries`
@@ -1303,6 +1397,29 @@ The management API has multiple resources to provide information regarding the d
         {"message":"Enabled tracing for ('HTTPIEP')"}
 	    ```
 	
+### ENABLE/DISABLE MESSAGE STATISTICS for INBOUND ENDPOINTS
+
+-	**Resource**: `/inbound-endpoints`
+
+	**Description**: Enable or disable message statistics for a specified inbound-endpoint.
+	**Example**:
+    
+    === "Request"
+        ```bash  
+	    	curl -X POST \
+        	  https://localhost:9164/management/inbound-endpoints \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "HTTPIEP",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response"          
+	    ```bash  
+        {"message":"Enabled statistics for ('HTTPIEP')"}
+	    ```
+	
 ### GET CONNECTORS
 
 -	**Resource**: `/connectors`
@@ -1478,6 +1595,31 @@ The management API has multiple resources to provide information regarding the d
     === "Response"        
 	    ```bash 
         {"message":"Enabled tracing for ('testSequenceTemplate')"}
+	    ```
+	
+
+### ENABLE/DISABLE MESSAGE STATISTICS for SEQUENCE TEMPLATES
+
+-	**Resource**: `/templates`
+
+	**Description**: Enable or disable message statistics for a specified sequence template.
+	**Example**:
+    
+    === "Request"
+        ```bash 
+	    	curl -X POST \
+        	  https://localhost:9164/management/templates \
+        	  -H 'authorization: Bearer TOKEN' \
+        	  -H 'content-type: application/json' \
+        	  -d '{
+        		"name": "testSequenceTemplate",
+        		"type": "sequence",
+        		"statistics": "enable"
+        	}' -k -i
+	    ```
+    === "Response"        
+	    ```bash 
+        {"message":"Enabled statistics for ('testSequenceTemplate')"}
 	    ```
 	
 ### GET SERVER INFORMATION


### PR DESCRIPTION
Add support for enabling/disabling message statistics for proxy services, endpoints, APIs, sequences, inbound endpoints, and sequence templates

docs for - https://github.com/wso2/product-micro-integrator/issues/4602


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Management API documentation with new operational examples and detailed request/response samples for enabling and disabling statistics. Coverage now includes proxy-services, endpoints, APIs, sequences, inbound-endpoints, and templates. Documentation provides comprehensive guidance on per-resource statistics management, allowing users to control observability and monitoring capabilities for all resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->