### PR TITLE
Adding mediator id to logs

### DIFF
--- a/en/docs/observe-and-manage/classic-observability-logs/configuring-log4j2-properties.md
+++ b/en/docs/observe-and-manage/classic-observability-logs/configuring-log4j2-properties.md
@@ -718,7 +718,7 @@ Here,
 
 ### Configuring mediator ID in log patterns
 
-Starting from MI 4.6.0, the **Mediator ID** is automatically included in error logs (`wso2error.log`) for mediation-related errors. You can also configure other log appenders to include the mediator ID by updating their layout pattern.
+The **Mediator ID** is automatically included in error logs (`wso2error.log`) for mediation-related errors. You can also configure other log appenders to include the mediator ID by updating their layout pattern.
 
 The mediator ID follows a hierarchical format that identifies the exact location of the mediator in your integration flow:
 

--- a/en/docs/observe-and-manage/classic-observability-logs/monitoring-logs.md
+++ b/en/docs/observe-and-manage/classic-observability-logs/monitoring-logs.md
@@ -121,7 +121,7 @@ Below is an example of a server error entry recorded in the error log file.
 
 ### Mediator ID in error logs
 
-Starting from MI 4.6.0, the `wso2error.log` file automatically includes the **Mediator ID** for mediation-related errors. This identifier helps you quickly pinpoint the exact mediator in your integration flow that caused the error, significantly improving debugging efficiency.
+The `wso2error.log` file automatically includes the **Mediator ID** for mediation-related errors. This identifier helps you quickly pinpoint the exact mediator in your integration flow that caused the error, significantly improving debugging efficiency.
 
 The mediator ID follows a hierarchical format:
 


### PR DESCRIPTION
## Purpose
This PR contains the doc updates related to adding mediator id to logs.

Related issue: https://github.com/wso2/product-micro-integrator/issues/4610


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on including a Mediator ID in log patterns, with examples and usage notes.
  * Documented the hierarchical Mediator ID format, its components, and sample log lines.
  * Described conditional display (hide/show) when the ID is empty and behavior when the ID is unavailable.
  * Added tips for enabling Mediator ID in error logs and other appenders; noted context-specific scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->