### PR TITLE
Add Doc for Configuring Crypto Provider

### DIFF
--- a/en/docs/install-and-setup/setup/security/configuring-the-crypto-provider.md
+++ b/en/docs/install-and-setup/setup/security/configuring-the-crypto-provider.md
@@ -85,7 +85,7 @@ Use this provider if your environment requires FIPS compliance or operates under
 Before enabling **BCFIPS**, you must add the required FIPS-compliant JARs to the MI runtime.
 Use the provided script in the `<MI_HOME>/bin` directory:
 
-=== "Linux / macOS"
+=== "Linux/macOS"
     ```
     cd <MI_HOME>/bin/
     sh fips.sh
@@ -103,7 +103,7 @@ This downloads and installs the required **bc-fips**, **bcpkix-fips**, **bctls-f
 
 To verify that the required changes were applied successfully:
 
-=== "Linux / macOS"
+=== "Linux/macOS"
     ```
     cd <MI_HOME>/bin/
     sh fips.sh VERIFY
@@ -115,9 +115,9 @@ To verify that the required changes were applied successfully:
     fips.bat VERIFY
     ```
 
-The script will check for the presence of required JARs and confirm whether the product is FIPS dependency-complete.
+The script will check for the presence of required JARs and confirm whether the product has all required FIPS dependencies.
 
-#### Step 3: Enable BCFIPS 
+#### Step 3: Enable BCFIPS
 
 Once the prerequisites are in place, start the server with:
 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -136,7 +136,7 @@ nav:
                   - Use Hashicorp Secrets: install-and-setup/setup/security/using-hashicorp-secrets.md
                   - Use Symmetric Encryption: install-and-setup/setup/security/single-key-encryption.md
               - Secure the Management API: install-and-setup/setup/security/securing-management-api.md
-              - Configure Crypto Providers: install-and-setup/setup/security/configuring-the-crypto-provider.md
+              - Configure the Crypto Provider: install-and-setup/setup/security/configuring-the-crypto-provider.md
           - Message Brokers:
               - AMQP (RabbitMQ):
                   - Deploy RabbitMQ: install-and-setup/setup/brokers/deploy-rabbitmq.md


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for configuring crypto providers, covering BC and BCFIPS enablement, keystore/truststore choices (JKS, BCFKS, PKCS12), FIPS prerequisites, provisioning steps, deployment configuration updates, and verification procedures.
  * Added a navigation entry under Install and Setup → Security to surface the new crypto provider configuration guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->