### PR TITLE
Mention the config file path in the diagnostic tool configs.

### DIFF
--- a/en/docs/reference/troubleshooting/utilizing-runtime-diagnostic-tool.md
+++ b/en/docs/reference/troubleshooting/utilizing-runtime-diagnostic-tool.md
@@ -18,6 +18,9 @@ There are four main components in the tool:
 
 The tool is packaged inside the product distribution with default configurations. The configurations can be customized based on user requirements. By default, the diagnostic tool is enabled.
 
+!!! note
+    All the configurations described in this section should be added to the `<MI_HOME>/conf/deployment.toml` file.
+
 ### Server Configurations
 
 The table given below describes the server configurations.


### PR DESCRIPTION
## Purpose
Mention the config file path in the diagnostic tool configs.
Fixes: https://github.com/wso2/docs-mi/issues/1921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the troubleshooting guide for the runtime diagnostic tool to state that configuration entries should be added to the product’s deployment configuration file located in the product home conf directory. Notes were added in relevant configuration sections to improve setup and deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->