### PR TITLE
Add configurations related to Post Quantum TLS

### DIFF
--- a/en/docs/develop/create-integration-project.md
+++ b/en/docs/develop/create-integration-project.md
@@ -56,7 +56,7 @@ Follow the below steps to create an integration project using the WSO2 Integrato
 !!! note
     You need the following to work with the MI for VS Code extension.
 
-    - Java Development Kit (JDK) version 21
+    - Java Development Kit (JDK) version 25
     - WSO2 Integrator:  MI 4.6.0 runtime
 
     If you don't have them installed in your local machine, these will be automatically prompted for downloading and configured by the WSO2 Integrator: MI for VS Code extension during the project creation step:

--- a/en/docs/get-started/build-first-ai-integration/first-integration-ai-chatbot.md
+++ b/en/docs/get-started/build-first-ai-integration/first-integration-ai-chatbot.md
@@ -53,7 +53,7 @@ To develop the above scenario, let us get started with creating an integration p
 !!! note
     You need the following to work with the MI for VS Code extension.
 
-    - Java Development Kit (JDK) version 21
+    - Java Development Kit (JDK) version 25
     - WSO2 Integrator:  MI 4.6.0 runtime
 
     If you don't have them installed on your local machine, these will be automatically prompted for downloading and configured by the WSO2 Integrator: MI for VS Code extension during the project creation step:

--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -68,7 +68,7 @@ To develop the above scenario, let's get started with creating an integration pr
 !!! note
     You need the following to work with the MI for VS Code extension.
 
-    - Java Development Kit (JDK) version 21
+    - Java Development Kit (JDK) version 25
     - WSO2 Integrator:  MI 4.6.0 runtime
 
     If you don't have them installed on your local machine, these will be automatically prompted for downloading and configured by the WSO2 Integrator: MI for VS Code extension during the project creation step:

--- a/en/docs/install-and-setup/setup/security/configuring-keystores.md
+++ b/en/docs/install-and-setup/setup/security/configuring-keystores.md
@@ -30,14 +30,27 @@ If you want to change the [default primary keystore](#the-default-keystore-confi
 
 3. Open the `deployment.toml` file and add the relevant configurations as described below.
 
-    ```toml
-    [keystore.primary]
-    file_name="repository/resources/security/wso2carbon.jks"
-    type="JKS"
-    password="wso2carbon"
-    alias="wso2carbon"
-    key_password="wso2carbon"
-    ```
+    === "JKS"
+
+        ```toml
+        [keystore.primary]
+        file_name="repository/resources/security/wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
+
+    === "PKCS12"
+
+        ```toml
+        [keystore.primary]
+        file_name="repository/resources/security/wso2carbon.p12"
+        type="PKCS12"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
 
     Find more details about [keystore parameters]({{base_path}}/reference/config-catalog-mi/#primary-keystore).
     
@@ -62,14 +75,27 @@ Follow the steps given below to separate the keystore that is used for encryptin
 
 3.  Open the `deployment.toml` file and add the relevant configurations as described below.
 
-    ```toml
-    [keystore.internal]
-    file_name="repository/resources/security/wso2carbon.jks"
-    type="JKS"
-    password="wso2carbon"
-    alias="wso2carbon"
-    key_password="wso2carbon"
-    ```
+    === "JKS"
+
+        ```toml
+        [keystore.internal]
+        file_name="repository/resources/security/wso2carbon.jks"
+        type="JKS"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
+
+    === "PKCS12"
+
+        ```toml
+        [keystore.internal]
+        file_name="repository/resources/security/wso2carbon.p12"
+        type="PKCS12"
+        password="wso2carbon"
+        alias="wso2carbon"
+        key_password="wso2carbon"
+        ```
 
     Find more details about [internal keystore parameters]({{base_path}}/reference/config-catalog-mi/#internal-keystore).
             
@@ -95,3 +121,79 @@ If you want to change the [default truststore](#the-default-keystore-configurati
     ```
 
 3. [Import the required certificates]({{base_path}}/install-and-setup/setup/security/importing-ssl-certificate#importing-ssl-certificates-to-a-truststore) to the truststore.
+
+## Add new keys to an existing keystore
+
+The following guides explain how you can add new keys to existing keystores.
+
+### Add an asymmetric key pair to an existing keystore
+
+To add a key,
+
+1. Navigate to the [default keystore](#the-default-keystore-configuration) or other existing keystore on a terminal.
+
+2. Execute the following command.
+
+    === "Format"
+
+        ```bash
+        keytool -genkey -alias <public_certificate_alias> -keyalg RSA -keysize 2048 -keystore <keystore_name> -storetype <keystore_type> -dname "CN=<<Common Name>>,OU=<<Organization Unit>>,O=<<Organization>>,L=<<Locality>>,S=<<StateofProvice Name>>,C=<<Country Name>>" -storepass <keystore_password> -keypass <private_key_password>
+        ```
+
+    === "Sample command (JKS)"
+
+        ``` bash
+        keytool -genkey -alias newkey -keyalg RSA -keysize 2048 -keystore wso2carbon.jks -dname "CN=localhost, OU=IT,O={{base_path}},L=SL,S=WS,C=LK" -storepass wso2carbon -keypass wso2carbon
+        ```
+
+    === "Sample command (PKCS12)"
+
+        ``` bash
+        keytool -genkey -alias newkey -keyalg RSA -keysize 2048 -keystore wso2carbon.p12 -storetype PKCS12 -dname "CN=localhost, OU=IT,O={{base_path}},L=SL,S=WS,C=LK" -storepass wso2carbon -keypass wso2carbon
+        ```
+
+    !!! tip  
+        If you are planning to delete the newly added keys in the future, it is recommended to maintain separate keystores for internal and external encryption purposes.
+
+This newly added key can be used for different purposes.
+
+### Add a symmetric secret to a PKCS12 keystore
+
+To create a PKCS12 keystore with an AES key or add an existing key to the keystore, use the following command. If the keystore is not available, new PKCS12 keystore will be created.
+
+=== "Format"
+
+    ``` bash
+
+    keytool -genseckey -alias <SECRET_ALIAS> -keyalg AES -keysize 256 -keystore <KEYSTORE_NAME> -storetype PKCS12 -storepass <KEYSTORE_PASSWORD> -keypass <KEYSTORE_PASSWORD>
+
+    ```
+
+
+=== "Sample keytool command"
+
+    ``` bash
+
+    keytool -genseckey -alias secretkey -keyalg AES -keysize 256 -keystore keystore.p12 -storetype PKCS12 -storepass password -keypass password
+
+    ```
+
+!!! abstract ""
+
+    **Example**
+
+    Follow the instructions given below to set the newly added key for symmetric encryption using cipher tool:
+
+    1. Open the `deployment.toml` file in the `<MI_HOME>/conf` directory.
+
+    2. Update the `alias` parameter under the `[keystore.internal]` element with the new keystore `alias`.       
+
+        ```toml
+        [keystore.internal]
+        file_name = "keystore.p12"
+        password = "password"
+        key_password = "password"
+        type = "PKCS12"
+        alias= "secretkey"
+        ```
+

--- a/en/docs/install-and-setup/setup/security/creating-keystores.md
+++ b/en/docs/install-and-setup/setup/security/creating-keystores.md
@@ -14,18 +14,30 @@ You can follow the steps in this section to create a new keystore with a private
 1. Open a command prompt and go to the `MI_HOME/repository/resources/security/` directory.
 2. Create the keystore that includes the private key by executing the following command:
 
-    ```bash
-    keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.jks -dname "CN=<testdomain.org>, OU=Home,O=Home,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword
-    ```
-    This command will create a keystore with the following details:
+    === "JKS"
+        ```bash
+        keytool -genkey -alias newcert -keyalg RSA -keysize 2048 -keystore newkeystore.jks -dname "CN=<testdomain.org>, OU=Home,O=Home,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword
+        ```
+        This command will create a keystore with the following details:
 
-    * Keystore name: `newkeystore.jks`
-    * Alias of public certificate: `newcert`
-    * Keystore password: `mypassword`
-    * Private key password: `mypassword` (this is required to be the same as the keystore password)
+        * Keystore name: `newkeystore.jks`
+        * Alias of public certificate: `newcert`
+        * Keystore password: `mypassword`
+        * Private key password: `mypassword` (this is required to be the same as the keystore password)
 
-    !!! Note
-        If you did not specify values for the '-keypass' and the '-storepass' in the above command, you will be asked to give a value for the '-storepass' (password of the keystore). As a best practice, use a password generator to generate a strong password. You will then be asked to enter a value for -keypass. Click **Enter** because we need the same password for both the keystore and the key. Also, if you did not specify values for -dname, you will be asked to provide those details individually.
+    === "PKCS12"
+        ```bash
+        keytool -genkeypair -alias newcert -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore newkeystore.p12 -dname "CN=<testdomain.org>, OU=Home,O=Home,L=SL,S=WS,C=LK" -storepass mypassword -keypass mypassword
+        ```
+        This command will create a keystore with the following details:
+
+        * Keystore name: `newkeystore.p12`
+        * Alias of public certificate: `newcert`
+        * Keystore password: `mypassword`
+        * Private key password: `mypassword` (this is required to be the same as the keystore password)
+
+  !!! Note
+      If you did not specify values for the '-keypass' and the '-storepass' in the above command, you will be asked to give a value for the '-storepass' (password of the keystore). As a best practice, use a password generator to generate a strong password. You will then be asked to enter a value for -keypass. Click **Enter** because we need the same password for both the keystore and the key. Also, if you did not specify values for -dname, you will be asked to provide those details individually.
 
 3. Open the `MI_HOME/repository/resources/security/` directory and check if the new keystore file is created. Make a backup of it and move it to a secure location. This is important as it is the only place with your private key.
 

--- a/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
+++ b/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
@@ -50,6 +50,9 @@ Dynamic secrets are specified in configurations as environment variables, system
 
 Running the Cipher Tool will first encrypt any [static secrets](#static-secrets) defined in the `[secrets]` section, and then enable all the secrets (static as well as dynamic) in the environment.
 
+!!! Note
+    While you are able to encrypt passwords using symmetric or asymmetric encryption, it is recommended to use symmetric encryption due to its greater resilience towards emerging post-quantum threats. Asymmetric encryption methods like RSA are not recommended due to their vulnerability to quantum computing capabilities.
+
 ### In a VM environment
 
 In a <b>VM environment</b>, you need to manually run the Cipher Tool as follows:
@@ -60,14 +63,20 @@ In a <b>VM environment</b>, you need to manually run the Cipher Tool as follows:
 1.  Open a terminal, navigate to the `<MI_HOME>/bin/` directory.
 2.  Execute the `-Dconfigure` command with the cipher tool script as shown below.
 
-    === "On Linux"
-        ```bash 
-        ./ciphertool.sh -Dconfigure
-        ```
-    === "On Windows"
-        ```bash 
-        ./ciphertool.bat -Dconfigure
-        ```
+    === "Asymmetric encryption"
+        !!! Warning
+             Asymmetric encryption methods like RSA are not recommended due to their vulnerability to post-quantum threats.
+
+        - For Linux: `./ciphertool.sh -Dconfigure`
+        - For Windows: `ciphertool.bat -Dconfigure`
+
+    === "Symmetric encryption"
+        !!! Note
+            To support symmetric encryption, you should have a symmetric secret in an internal keystore of type PKCS12. Follow the instructions [here]({{base_path}}/install-and-setup/setup/security/configuring-keystores/#add-a-symmetric-secret-to-a-pkcs12-keystore) to add one.
+
+        - For Linux: `./ciphertool.sh -Dconfigure -Dsymmetric`
+        - For Windows: `ciphertool.bat -Dconfigure -Dsymmetric`
+
 
 ### In Docker/Kubernetes environments
 

--- a/en/docs/install-and-setup/setup/security/importing-ssl-certificate.md
+++ b/en/docs/install-and-setup/setup/security/importing-ssl-certificate.md
@@ -58,13 +58,26 @@ Follow the steps given below to import the CA-signed public key certificate into
 
 1. Get a copy of the trust store file from the `MI_HOME/repository/resources/security/` directory.
 2. Export the public key from your .jks file using the following command.
-    ```bash
-    keytool -export -alias certalias -keystore newkeystore.jks -file <public key name>.pem
-    ```
+
+    === "JKS"
+        ```bash
+        keytool -export -alias certalias -keystore newkeystore.jks -file <public key name>.pem
+        ```
+    === "PKCS12"
+        ```bash
+        keytool -export -alias certalias -keystore newkeystore.p12 -storetype PKCS12 -file <public key name>.pem
+        ```
+
 3. Import the public key you extracted in the previous step to your trust store using the following command.
-    ```bash
-    keytool -import -alias certalias -file <public key name>.pem -keystore client-truststore.jks -storepass wso2carbon
-    ```
+
+    === "JKS"
+        ```bash
+        keytool -import -alias certalias -file <public key name>.pem -keystore client-truststore.jks -storepass wso2carbon
+        ```
+    === "PKCS12"
+        ```bash
+        keytool -import -alias certalias -file <public key name>.pem -keystore client-truststore.p12 -storetype PKCS12 -storepass wso2carbon
+        ```
 
 ## What's next?
 

--- a/en/docs/install-and-setup/setup/transport-configurations/configuring-transports.md
+++ b/en/docs/install-and-setup/setup/transport-configurations/configuring-transports.md
@@ -108,6 +108,25 @@ listener.preferred_ciphers = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_
 
     $ java -jar testsslserver.jar localhost 8253
 
+### Configure post-quantum TLS
+
+As quantum computing becomes a reality, traditional public key algorithms like RSA and ECC grow increasingly vulnerable. WSO2 Integrator: MI mitigates this issue by supporting **Post-Quantum Cryptography (PQC)** through hybrid key exchange algorithms.
+
+A hybrid key agreement algorithm combines a classical algorithm with a post-quantum algorithm to establish a shared secret. This approach keeps communication secure even if one algorithm is compromised, helping systems transition seamlessly to post-quantum cryptography.
+
+WSO2 Integrator: MI supports post-quantum security for both Inbound connections (Between clients and the server) and Outbound connections (Between the server and other external services). 
+
+To enable post-quantum security, update the following properties in the deployment.toml file:
+
+```toml
+[jsse_provider]
+provider_name = "BC"
+
+[transport.http]
+listener.secured_protocols="TLSv1.3" # TLSv1.3 must be added to the list of enabled protocols to use post-quantum key exchange algorithms
+sender.secured_protocols="TLSv1.3"
+```
+
 ## Configuring the VFS transport
 
 This transport is used to process files in a specified source directory. After processing the files, the files are moved to a specified location or deleted. Note that files cannot remain in the source directory after processing because they will be processed again. Therefore, if you need to maintain these files or keep track of which files have been processed, specify the option to move them instead of deleting them after processing. If you want to move files into a database, use the VFS transport and the [DBReport Mediator]({{base_path}}/reference/mediators/db-report-mediator).


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Java Development Kit (JDK) version requirement from 21 to 25 across setup guides.
  * Enhanced keystore documentation with explicit support for both JKS and PKCS12 formats, including separate configuration examples for each type.
  * Added new guidance on adding keys to existing keystores and symmetric encryption pathways.
  * Introduced post-quantum cryptography and TLS 1.3 configuration documentation for improved security resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->