### PR TITLE
Add RHEL 9 compatibility with Temurin OpenJDK 11, 17, and 21

### DIFF
--- a/en/docs/install-and-setup/install/installation-prerequisites.md
+++ b/en/docs/install-and-setup/install/installation-prerequisites.md
@@ -64,25 +64,25 @@ The details of the tested environments for the WSO2 Integrator: MI 4.5.0 runtime
 
 The WSO2 Integrator: MI runtime is tested with the following operating systems:
 
-| Operating System         | Versions   |
-|--------------------------|------------|
-| Windows                  | 2025       |
-| Ubuntu                   | 24.04      |
-| Red Hat Enterprise Linux | 10         |
-| Rocky Linux              | 10         |
-| MacOS                    | 15.7      |
-| SUSE Linux               | 15         |
+| Operating System         | Versions |
+|--------------------------|----------|
+| Windows                  | 2025     |
+| Ubuntu                   | 24.04    |
+| Red Hat Enterprise Linux | 9.7, 10  |
+| Rocky Linux              | 10       |
+| MacOS                    | 15.7     |
+| SUSE Linux               | 15       |
 
 ### Tested JDKs
 
 The WSO2 Integrator: MI runtime is tested with the following JDKs:
 
-| JDK         |Versions|
-|-------------|--------|
-| CorrettoJDK | 11, 17, 21 |
-| AdoptOpenJDK | 11, 17, 21 |
-| OpenJDK     | 11, 17, 21 |
-| Oracle JDK  | 11, 17, 21 |
+| JDK               | Versions   |
+|-------------------|------------|
+| CorrettoJDK       | 11, 17, 21 |
+| Temurin OpenJDK   | 11, 17, 21 |
+| OpenJDK           | 11, 17, 21 |
+| Oracle JDK        | 11, 17, 21 |
 
 ### Tested DBMSs
 


### PR DESCRIPTION
## Purpose
Updating the documentation as verified by running MI 4.5.0 integration tests on RHEL 9.7 using Temurin OpenJDK 11, 17, and 21.