### PR TITLE
Fix outdated SNMP monitoring documentation 

### DIFF
--- a/en/.spelling
+++ b/en/.spelling
@@ -2911,10 +2911,10 @@ Jconsole
 LastHourAvgLatency
 http
 www.snmp4j.org
-snmp4j-2
-1.0.jar
-snmp4j-agent-2
-0.6.jar
+snmp4j-3
+8.0.jar
+snmp4j-agent-3
+1.2.jar
 Occured
 throughputs
 PROMETHEUS_HOME

--- a/en/docs/observe-and-manage/classic-observability-metrics/snmp-monitoring.md
+++ b/en/docs/observe-and-manage/classic-observability-metrics/snmp-monitoring.md
@@ -5,18 +5,15 @@ Simple Network Management Protocol (SNMP) is an Internet-standard protocol for
 ## Enabling SNMP
 
 1.  Download the following jar files from [http://www.snmp4j.org](http://www.snmp4j.org/) and add them to the
-    `<MI_HOME>/lib` directory. 
-    
-     -  **snmp4j-2.1.0.jar**
-     -  **snmp4j-agent-2.0.6.jar**
-  
-2.  Enable SNMP in the `ei.toml` file, stored in the `<MI_HOME>/conf/` file by
-    adding the following entry: 
-    
-     ```toml
-     [synapse_properties]
-     'synapse.snmp.enabled'=true
-     ``` 
+    `<MI_HOME>/lib` directory.
+
+    !!! note
+        SNMP4J version 3.x and above is recommended for Java 8 and later. Use version 2.x only if you are on an older Java version.
+
+     -  **snmp4j-3.8.0.jar** (or the latest 3.x version)
+     -  **snmp4j-agent-3.1.2.jar** (or the latest 3.x version)
+
+Once the jar files are added to the `<MI_HOME>/lib` directory, restart the WSO2 MI server to activate SNMP monitoring.
 
 The WSO2 Integrator: MI can now monitor MBeans with SNMP. For example:
 


### PR DESCRIPTION
Fixes #1621

  - Update SNMP4J jar references from 2.1.0/2.0.6 to 3.8.0/3.1.2 (3.x recommended for Java 8+)
  - Remove non-existent synapse.snmp.enabled property from ei.toml instructions
  - Add note clarifying version compatibility and restart requirement
  - Update spelling dictionary with new version entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SNMP monitoring guidance to use SNMP4J 3.x, added Java 8+ compatibility note, instructions to place libraries in the server lib directory, and explicit server restart guidance; removed the legacy SNMP enable configuration reference.

* **Chores**
  * Upgraded SNMP4J libraries from 2.x to 3.x for improved compatibility and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->