### PR TITLE
Add fileNameEncoding vfs URL parameter

### DIFF
--- a/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
@@ -508,6 +508,14 @@ When you use the [transport.vfs.FileURI](#vfs-transport-file_url) parameter, you
            When a file read/write location is a bind mount volume, this property needs to be set to <code>true</code>.
          </td>
       </tr>   
+      <tr>
+         <td>
+           fileNameEncoding
+         </td>
+         <td>
+           Encoding of the file names in the file host. This is required when the file names are in different encoding than UTF-8 ex: ISO-8859-1.
+         </td>
+      </tr>
    </tbody>
 </table>
 


### PR DESCRIPTION
Add fileNameEncoding vfs URL parameter
Related to wso2/product-micro-integrator/issues/4651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new VFS transport setting, fileNameEncoding, explaining when and how to configure it for non-UTF-8 file name encodings (e.g., ISO-8859-1). Clarifies placement and usage within VFS transport parameters and the requirement to specify this encoding when the host uses a different file name charset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->