### PR TITLE
Add RHEL as a tested operating system

### DIFF
--- a/en/docs/install-and-setup/install/icp-installation-prerequisites.md
+++ b/en/docs/install-and-setup/install/icp-installation-prerequisites.md
@@ -26,6 +26,7 @@ The Integration Control Plane is tested with the following operating systems:
 | Windows                  | 11       |
 | Ubuntu                   | 22.04    |
 | MacOS                    | 13.6     |
+| Linux(RHEL)              | 9.4      |
 
 ### Tested JDKs
 


### PR DESCRIPTION
## Purpose
- Add RHEL as a tested operting system
- Resolves https://github.com/wso2-enterprise/wso2-integration-internal/issues/2428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linux(RHEL) 9.4 to the list of tested operating systems for ICP installation prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->