### PR TITLE
[430] Update email connector docs with OAuth2 configs

### DIFF
--- a/en/docs/reference/connectors/email-connector/email-connector-config.md
+++ b/en/docs/reference/connectors/email-connector/email-connector-config.md
@@ -112,6 +112,50 @@ The following operations allow you to work with the Email Connector. Click an op
         </tr>
     </table>
 
+    The following OAuth2 authentication configurations can be used for IMAP and IMAPS connections. **Note**: These configurations are available from Email connector version 1.1.0 and above.
+    <table>
+        <tr>
+            <th>Parameter Name</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+        <tr>
+            <td>enableOAuth2</td>
+            <td>Whether to enable OAuth2 authentication. Possible values are <code>true</code> or <code>false</code>.</td>
+            <td>Default value is <code>false</code>.</td>
+        </tr>
+        <tr>
+            <td>grantType</td>
+            <td>The OAuth2 grant type. For example: <code>AUTHORIZATION_CODE</code>, <code>CLIENT_CREDENTIALS</code>.</td>
+            <td>Required if <code>enableOAuth2</code> is <code>true</code>.</td>
+        </tr>
+        <tr>
+            <td>clientId</td>
+            <td>The Client ID obtained when registering your application.</td>
+            <td>Required if <code>enableOAuth2</code> is <code>true</code>.</td>
+        </tr>
+        <tr>
+            <td>clientSecret</td>
+            <td>The Client Secret obtained when registering your application.</td>
+            <td>Required if <code>enableOAuth2</code> is <code>true</code>.</td>
+        </tr>
+        <tr>
+            <td>tokenUrl</td>
+            <td>The token endpoint URL used to generate the access token.</td>
+            <td>Required if <code>enableOAuth2</code> is <code>true</code>.</td>
+        </tr>
+        <tr>
+            <td>scope</td>
+            <td>The scope for the OAuth2 connection.</td>
+            <td>Required if the <code>grantType</code> is <code>CLIENT_CREDENTIALS</code>.</td>
+        </tr>
+        <tr>
+            <td>refreshToken</td>
+            <td>The generated refresh token.</td>
+            <td>Required if the <code>grantType</code> is <code>AUTHORIZATION_CODE</code>.</td>
+        </tr>
+        </table>
+
     **Sample configuration**
 
     ```xml


### PR DESCRIPTION
## Purpose

Update email connector docs with OAuth2 configs

<img width="1333" height="549" alt="Screenshot 2026-03-09 at 15 08 35" src="https://github.com/user-attachments/assets/df7a48e5-7168-4d76-b563-bc88daf84f4e" />

Port https://github.com/wso2/docs-apim/pull/6733 to MI 4.3.0 Docs