### PR TITLE
Add disable_thread_switch_on_blocking_call to docs

### DIFF
--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -10952,7 +10952,7 @@ inbound.max_threads = 100</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>By default, Axis2 spawns a new thread to handle each outgoing message. This is done to enable non-blocking message processing behaviour. But this might exhaust the thread pool and cause erroneous behaviour in guaranteed transaction scenarios. You can use this configuration to disable this behaviour when dealing with queuing transports like JMS. This thread-switching behaviour can also be disabled at the mediation level with the use of a <a href="{{base_path}}/reference/mediators/property-reference/generic-properties/#clientapinonblocking">property.</a></p>
+                                        <p>By default, Axis2 spawns a new thread to handle each outgoing message. This is done to enable non-blocking message processing behaviour. But this might exhaust the thread pool and cause erroneous behaviour in guaranteed transaction scenarios. You can use this configuration to disable this behaviour when dealing with queuing transports like JMS. This thread-switching behaviour can also be disabled at the mediation level with the use of a <a href="{{base_path}}/reference/mediators/property-reference/generic-properties/#clientapinonblocking">property</a>.</p>
                                     </div>
                                 </div>
                             </div>

--- a/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
@@ -85,6 +85,10 @@ The following parameters can be specified under the connection factory configura
     <td>parameter.'rabbitmq.max.inbound.message.body.size'</td>
     <td>The maximum size limit in bytes for inbound message bodies.</td>
   </tr>
+  <tr>
+    <td>parameter.factory_executor_pool_size</td>
+    <td>The size of the executor pool for the connection factory, which determines how many consumer callbacks can be processed concurrently per connection. Increase this to allow more concurrent delivery processing for the <code>rabbitmq.concurrent.consumer.count</code> parameter when the default pool size (based on available CPU cores) is insufficient.</td>
+  </tr>
 </table>
 
 ### SSL/TLS parameters
@@ -234,6 +238,10 @@ present. If set to <code>false</code>, the WSO2 Integrator: MI will assume that 
             The content type of the consumer. <b>Note</b>: If the content type is specified in the message, this parameter does not override the specified content type. The default value is <code>text/xml</code>. <br><br>
             <b>Note:</b> If you are consuming SOAP messages, set this parameter to <code>application/soap+xml</code> or <code>text/xml</code>. For other XML messages, set this parameter to <code>application/xml</code>.
          </td>
+      </tr>
+      <tr>
+        <td>rabbitmq.concurrent.consumer.count</td>
+        <td>The number of concurrent consumers for the RabbitMQ connection. Default is 1.</td>
       </tr>            
    </tbody>
 </table>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Related to https://github.com/wso2/product-micro-integrator/issues/4331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new boolean configuration parameter synapse.disable_thread_switch_on_blocking_call (default: false) to control thread-switching behavior for blocking calls.
  * Added docs for RabbitMQ transport settings: parameter.factory_executor_pool_size to tune connection factory executor pool size, and rabbitmq.concurrent.consumer.count to configure number of concurrent consumers (default: 1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->