### PR TITLE
[450] Update file connector 5.x docs with Cache File Stats parameter

### DIFF
--- a/en/docs/reference/connectors/file-connector/5.x/file-connector-config.md
+++ b/en/docs/reference/connectors/file-connector/5.x/file-connector-config.md
@@ -612,6 +612,27 @@ There are different connection configurations that can be used for the above pro
             No
             </td>
         </tr>
+        <tr>
+        <td>
+            Cache File Stats
+        </td>
+        <td>
+            cacheFileStats
+        </td>
+        <td>
+            Boolean
+        </td>
+        <td>
+            Enable this to cache file stats for better performance. Since the stats(metadata) are cached, if another process modifies the metadata while the file is being read, those changes may not be detected by the File Connector operation.</br>
+            Available in file-connector <b>v5.0.4</b> and above.
+        </td>
+        <td>
+            false
+        </td>
+        <td>
+           No
+        </td>
+    </tr>
     </table>
 
     !!!info


### PR DESCRIPTION
## Purpose

Update file connector 5.x docs with Cache File Stats parameter.

<img width="1445" height="989" alt="Screenshot 2026-03-17 at 09 01 11" src="https://github.com/user-attachments/assets/c3d1756b-3255-4ff2-b0a0-897b23a7f7da" />

## Related PRs
https://github.com/wso2-extensions/esb-connector-file/pull/288