### PR TITLE
Update OS and DBMS versions according to the performed compatibility testing

### DIFF
--- a/en/docs/install-and-setup/install/installation-prerequisites.md
+++ b/en/docs/install-and-setup/install/installation-prerequisites.md
@@ -70,8 +70,8 @@ The WSO2 Integrator: MI runtime is tested with the following operating systems:
 | Ubuntu                   | 24.04    |
 | Red Hat Enterprise Linux | 9.7, 10  |
 | Rocky Linux              | 10       |
-| MacOS                    | 15.7     |
-| SUSE Linux               | 15       |
+| MacOS                    | 26.3     |
+| SUSE Linux               | 16       |
 
 ### Tested JDKs
 
@@ -90,11 +90,11 @@ The WSO2 Integrator: MI runtime is tested with the following databases:
 
 | DBMS                 | Versions           |
 |----------------------|--------------------|
-| MySQL                | 8, 9             |
-| Oracle               | 12c release 2, 19c |
-| Microsoft SQL Server | 2022               |
-| PostgreSQL           | 17.2         |
-| MariaDB              | 10.5               |
+| MySQL                | 8, 9               |
+| Oracle               | 19c, 26ai          |
+| Microsoft SQL Server | 2025               |
+| PostgreSQL           | 17.2, 18.3         |
+| MariaDB              | 10.5, 12.2         |
 | DB2                  | 11.5               |
 
 ### ARM compatibility


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation prerequisites: macOS testing updated to 26.3 and SUSE Linux to 16.
  * Expanded tested database compatibility: Oracle updated to 19c and 26ai; Microsoft SQL Server to 2025; PostgreSQL to include 17.2 and 18.3; MariaDB to include 10.5 and 12.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->