### PR TITLE
Add doc changes on OAuth timeout configurations

### DIFF
--- a/en/docs/reference/synapse-properties/endpoint-properties.md
+++ b/en/docs/reference/synapse-properties/endpoint-properties.md
@@ -829,6 +829,71 @@ You can use dynamic values for OAuth configurations such as XPATH, JSON expressi
 </endpoint>
 ```
 
+#### Token endpoint timeouts
+
+You can configure timeout values for the OAuth token endpoint request using the following parameters:
+
+<table>
+    <tr>
+        <th>Property</th>
+        <th>Description</th>
+        <th>Required</th>
+    </tr>
+    <tr>
+        <td>connectionTimeout</td>
+        <td>
+            Maximum time (in milliseconds) allowed to establish a connection to the OAuth token endpoint.
+        </td>
+        <td>Optional</td>
+    </tr>
+    <tr>
+        <td>connectionRequestTimeout</td>
+        <td>
+            Maximum time (in milliseconds) to wait when obtaining a connection from the connection pool before making the token request.
+        </td>
+        <td>Optional</td>
+    </tr>
+    <tr>
+        <td>socketTimeout</td>
+        <td>
+            Maximum time (in milliseconds) to wait for data after the connection to the token endpoint is established.
+        </td>
+        <td>Optional</td>
+    </tr>
+</table>
+
+```xml
+<endpoint name="FoodEP" xmlns="http://ws.apache.org/ns/synapse">
+    <http method="get" uri-template="http://localhost:9192/service/foodservice">
+        <authentication>
+            <oauth>
+                <clientCredentials>
+                    <clientId>ADD_CLIENT_ID_HERE</clientId>
+                    <clientSecret>ADD_CLIENT_SECRET_HERE</clientSecret>
+                    <tokenUrl>https://localhost:9445/oauth2/token</tokenUrl>
+                    <authMode>header</authMode>
+                    <connectionTimeout>10000</connectionTimeout>
+                    <connectionRequestTimeout>10000</connectionRequestTimeout>
+                    <socketTimeout>15000</socketTimeout>
+                </clientCredentials>
+            </oauth>
+        </authentication>
+    </http>
+</endpoint>
+```
+
+!!! Note
+        You can also set these timeout parameters globally. To do so, add the following configuration to your `deployment.toml` file.
+
+        If you set the timeout values both globally and locally, the local values will take precedence over the global values.
+        ```
+        [synapse_properties]
+        'synapse.endpoint.http.oauth.token.endpoint.global.connection.timeout'=5000
+        'synapse.endpoint.http.oauth.token.endpoint.global.connection.request.timeout'=5000
+        'synapse.endpoint.http.oauth.token.endpoint.global.socket.timeout'=10000
+        'synapse.endpoint.http.oauth.enable.global.timeout.configs'=true
+        ```
+
 ### Quality of Service Properties
 
 QoS (Quality of Service) aspects such as WS-Security and WS-Addressing may be enabled on messages sent to an endpoint using `enableSec` and `enableAddressing` elements. Optionally, the WS-Security policies could be specified using the `policy` attribute.


### PR DESCRIPTION
## Purpose
> Add doc changed on OAuth timeout configs

<img width="839" height="762" alt="Screenshot 2026-03-27 at 07 31 23" src="https://github.com/user-attachments/assets/07db5131-b0a8-4ce0-96a7-bc68f6e29eca" />
<img width="836" height="253" alt="Screenshot 2026-03-27 at 07 31 14" src="https://github.com/user-attachments/assets/f434647f-49b5-4e5f-9ae4-6f3205baa40f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring Token endpoint timeouts under OAuth Properties, introducing three optional per-endpoint timeout parameters (connection, request, and socket) and describing the request stages they govern. Includes an updated example showing these timeout elements alongside OAuth fields, plus a note on equivalent global timeout configuration and that endpoint-level values override global settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->