### PR TITLE
Add fallbackReplayId parameter to Salesforce Inbound Endpoint configuration

### DIFF
--- a/en/docs/reference/connectors/salesforce-connectors/sf-inbound-endpoint-overview.md
+++ b/en/docs/reference/connectors/salesforce-connectors/sf-inbound-endpoint-overview.md
@@ -104,4 +104,12 @@ This reference page documents all the configuration parameters supported by the 
     <td><code>/home/kasun/Documents/SalesForceConnector/a.txt</code></td>
     <td>-</td>
   </tr>
+  <tr>
+    <td>fallbackReplayId</td>
+    <td>Fallback event ID to start reading messages if the event ID stored in the Registry is invalid. -2 to replay all events, or -1 to replay only new events. 
+    This is supported in version 2.1.16 and above.</td>
+    <td>No</td>
+    <td>-1 or -2</td>
+    <td>-</td>
+  </tr>
 </table>


### PR DESCRIPTION
ref - https://github.com/wso2/product-integrator-mi/issues/4768


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new optional `fallbackReplayId` configuration parameter in the Salesforce inbound endpoint. This parameter provides a fallback event ID to resume reading messages when the stored event ID becomes invalid. Supported from version 2.1.16 onwards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->