### PR TITLE
Update markdown copy logic to serve raw content via generated HTML pages instead of standalone files

### DIFF
--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -165,9 +165,22 @@
             try {
                 const markdown = await fetchFlattenedMarkdownForCurrentPage();
                 await navigator.clipboard.writeText(markdown);
+
+                // Show "Copied!" feedback on the button
+                const copyButton = menu.querySelector('.cp-copy');
+                const titleElement = copyButton.querySelector('.copy-page-item-title');
+                const originalText = titleElement.textContent;
+                titleElement.textContent = 'Copied!';
+
+                // Also show in button title attribute
                 const originalTitle = button.getAttribute('title');
                 button.setAttribute('title', 'Copied!');
-                setTimeout(() => button.setAttribute('title', originalTitle), 2000);
+
+                // Revert after 2 seconds
+                setTimeout(() => {
+                    titleElement.textContent = originalText;
+                    button.setAttribute('title', originalTitle);
+                }, 2000);
             } catch (err) {
                 console.error('Failed to copy:', err);
             }
@@ -201,6 +214,18 @@
 
     function init() {
         if (document.querySelector('.copy-page-container')) return;
+
+        // Don't show copy-page button on home page
+        const pathname = window.location.pathname;
+        const isHomePage = pathname === '/' ||
+                          pathname === '/docs-mi/' ||
+                          pathname === '/en/latest/' ||
+                          pathname === '/en/4.6.0/' ||
+                          pathname.endsWith('/index.html');
+
+        if (isHomePage) {
+            return;
+        }
 
         const editButton = document.querySelector('.md-content__button.md-icon[href*="/edit/"]');
         const viewButton = document.querySelector('.md-content__button.md-icon[href*="/raw/"]') ||

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -152,7 +152,10 @@
             setOpen(false);
         };
 
-        document.removeEventListener('click', handleGlobalClick);
+        if (window.activeGlobalClickHandler) {
+            document.removeEventListener('click', window.activeGlobalClickHandler);
+        }
+        window.activeGlobalClickHandler = handleGlobalClick;
         document.addEventListener('click', handleGlobalClick);
 
         const getPrompt = () => {
@@ -188,11 +191,8 @@
         });
 
         menu.querySelector('.cp-view').addEventListener('click', () => {
-            const pathname = window.location.pathname;
-            const mdPath = (pathname === '/' || pathname === '')
-                ? '/index.md'
-                : pathname.replace(/\/$/, '') + '.md';
-            window.location.href = window.location.origin + mdPath;
+            const mdUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
+            window.location.href = mdUrl;
             setOpen(false);
         });
 

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -222,8 +222,8 @@
                 const originalText = titleElement.textContent;
                 titleElement.textContent = 'Copied! Opening Claude...';
 
-                // Open Claude in new window
-                const claudeWindow = window.open('https://claude.ai/new', '_blank', 'noopener,noreferrer');
+                // Open Claude in new tab (avoid /new which triggers bot detection)
+                window.open('https://claude.ai', '_blank', 'noopener,noreferrer');
 
                 // Revert button text after a moment
                 setTimeout(() => {

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -196,10 +196,10 @@
             setOpen(false);
         });
 
-        const aiLinks = { 
-            '.cp-chatgpt': 'https://chat.openai.com/?q=', 
-            '.cp-claude': 'https://claude.ai/new?q=', 
-            '.cp-perplexity': 'https://www.perplexity.ai/search?q=' 
+        // ChatGPT and Perplexity still support query parameters
+        const aiLinks = {
+            '.cp-chatgpt': 'https://chat.openai.com/?q=',
+            '.cp-perplexity': 'https://www.perplexity.ai/search?q='
         };
 
         Object.entries(aiLinks).forEach(([selector, url]) => {
@@ -207,6 +207,32 @@
                 window.open(url + encodeURIComponent(getPrompt()), '_blank', 'noopener,noreferrer');
                 setOpen(false);
             });
+        });
+
+        // Claude handler - copy content to clipboard, then open Claude
+        menu.querySelector('.cp-claude').addEventListener('click', async () => {
+            try {
+                // Fetch and copy markdown content to clipboard
+                const markdown = await fetchFlattenedMarkdownForCurrentPage();
+                await navigator.clipboard.writeText(markdown);
+
+                // Show feedback on the button
+                const claudeButton = menu.querySelector('.cp-claude');
+                const titleElement = claudeButton.querySelector('.copy-page-item-title');
+                const originalText = titleElement.textContent;
+                titleElement.textContent = 'Copied! Opening Claude...';
+
+                // Open Claude in new window
+                const claudeWindow = window.open('https://claude.ai/new', '_blank', 'noopener,noreferrer');
+
+                // Revert button text after a moment
+                setTimeout(() => {
+                    titleElement.textContent = originalText;
+                }, 1500);
+            } catch (err) {
+                console.error('Failed to copy or open Claude:', err);
+            }
+            setOpen(false);
         });
 
         return container;

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -51,7 +51,10 @@
         const mdUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
         const res = await fetch(mdUrl, { cache: 'no-cache' });
         if (!res.ok) throw new Error("Fetch failed");
-        return await res.text();
+        const html = await res.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        return doc.body.textContent;
     }
 
     function createCopyPageButton() {
@@ -172,8 +175,11 @@
         });
 
         menu.querySelector('.cp-view').addEventListener('click', () => {
-            const mdUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
-            window.open(mdUrl, '_blank');
+            const pathname = window.location.pathname;
+            const mdPath = (pathname === '/' || pathname === '')
+                ? '/index.md'
+                : pathname.replace(/\/$/, '') + '.md';
+            window.location.href = window.location.origin + mdPath;
             setOpen(false);
         });
 

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -13,11 +13,26 @@
 
     /**
      * Derives the logical Markdown URL from the current HTML URL.
+     * First checks for a data-src-path attribute on the body element for the actual source path.
+     * Falls back to reconstructing from the HTML URL if the attribute is missing.
      * Logic:
      * - /en/4.6.0/guides/foo/index.html -> /en/4.6.0/guides/foo.md
      * - /en/4.6.0/guides/bar.html -> /en/4.6.0/guides/bar.md
      */
     function getFlattenedMarkdownUrlFromHtmlUrl(htmlUrl) {
+        // First, check if the page template provided the source path via data attribute
+        const srcPath = document.body.getAttribute('data-src-path');
+        if (srcPath) {
+            // Normalize the path: ensure it has .md extension and proper slashes
+            const u = new URL(htmlUrl);
+            const normalizedPath = srcPath.startsWith('/') ? srcPath : '/' + srcPath;
+            const mdPath = normalizedPath.endsWith('.md') ? normalizedPath : normalizedPath + '.md';
+            u.pathname = mdPath;
+            u.hash = ''; u.search = '';
+            return u.href;
+        }
+
+        // Fallback: reconstruct from the HTML URL (lossy, but works when data attribute is missing)
         const u = new URL(htmlUrl);
         u.hash = ''; u.search = '';
 
@@ -37,13 +52,13 @@
 
         const isVersion = /^\d+\.\d+\.\d+$/.test(folderName);
         const isLangOrVersion = isVersion || ['en', 'next', 'latest'].includes(folderName);
-        
-        if (isLangOrVersion) { 
-            u.pathname = `/${segments.join('/')}/index.md`; 
-        } else { 
-            u.pathname = parentPath ? `/${parentPath}/${folderName}.md` : `/${folderName}.md`; 
+
+        if (isLangOrVersion) {
+            u.pathname = `/${segments.join('/')}/index.md`;
+        } else {
+            u.pathname = parentPath ? `/${parentPath}/${folderName}.md` : `/${folderName}.md`;
         }
-        
+
         return u.href;
     }
 
@@ -243,11 +258,32 @@
 
         // Don't show copy-page button on home page
         const pathname = window.location.pathname;
-        const isHomePage = pathname === '/' ||
-                          pathname === '/docs-mi/' ||
-                          pathname === '/en/latest/' ||
-                          pathname === '/en/4.6.0/' ||
-                          pathname.endsWith('/index.html');
+
+        // Segment-based home page detection
+        const trimmed = pathname.replace(/^\/+|\/+$/g, '');
+        const segments = trimmed ? trimmed.split('/') : [];
+
+        // Root landing page (/) or no segments
+        let isHomePage = pathname === '/' || segments.length === 0;
+
+        // Single-segment top-level pages (e.g., /docs-mi/ or any single top-level folder)
+        if (segments.length === 1) {
+            // Could be a top-level folder like 'docs-mi' or a language like 'en'
+            // For these, we skip the button
+            isHomePage = true;
+        }
+
+        // Two-segment language/version landing pages (e.g., /en/latest/, /en/4.6.0/)
+        if (segments.length === 2) {
+            const lang = segments[0];
+            const version = segments[1];
+            const langWhitelist = ['en', 'next', 'latest'];
+            const versionPattern = /^(\d+\.\d+\.\d+|latest|next)$/;
+
+            if (langWhitelist.includes(lang) && versionPattern.test(version)) {
+                isHomePage = true;
+            }
+        }
 
         if (isHomePage) {
             return;

--- a/en/docs/assets/js/copy-page.js
+++ b/en/docs/assets/js/copy-page.js
@@ -1,9 +1,6 @@
 (function () {
     'use strict';
 
-    /**
-     * Icon SVG definitions matching the React component.
-     */
     const Icons = {
         Copy: `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z" /><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z" /></svg>`,
         Markdown: `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3h13.7zM9 11V5H7l-1.5 2.25L4 5H2v6h2V8l1.5 2L7 8v3h2zm2.99.5L14.5 8H13V5h-2v3H9.5l2.49 3.5z" /></svg>`,
@@ -14,42 +11,78 @@
         Perplexity: `<svg width="16" height="16" viewBox="0 0 34 38" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.12114 0.0400391L15.919 9.98864V9.98636V0.062995H18.0209V10.0332L28.8671 0.0400391V11.3829H33.3202V27.744H28.8808V37.8442L18.0209 28.303V37.9538H15.919V28.4604L5.13338 37.96V27.744H0.680176V11.3829H5.12114V0.0400391ZM14.3344 13.4592H2.78208V25.6677H5.13074V21.8167L14.3344 13.4592ZM7.23518 22.7379V33.3271L15.919 25.6786V14.8506L7.23518 22.7379ZM18.0814 25.5775V14.8404L26.7677 22.7282V27.744H26.7789V33.219L18.0814 25.5775ZM28.8808 25.6677H31.2183V13.4592H19.752L28.8808 21.7302V25.6677ZM26.7652 11.3829V4.81584L19.6374 11.3829H26.7652ZM14.3507 11.3829H7.22306V4.81584L14.3507 11.3829Z" /></svg>`
     };
 
-    function createCopyPageButton(markdownUrl) {
-        // Container
+    /**
+     * Derives the logical Markdown URL from the current HTML URL.
+     * Logic:
+     * - /en/4.6.0/guides/foo/index.html -> /en/4.6.0/guides/foo.md
+     * - /en/4.6.0/guides/bar.html -> /en/4.6.0/guides/bar.md
+     */
+    function getFlattenedMarkdownUrlFromHtmlUrl(htmlUrl) {
+        const u = new URL(htmlUrl);
+        u.hash = ''; u.search = '';
+
+        // Strip index.html AND .html extension
+        let cleanPath = u.pathname
+            .replace(/\/index\.html$/, '/')
+            .replace(/\.html$/, '')
+            .replace(/\/$/, '');
+
+        const segments = cleanPath.split('/').filter(Boolean);
+
+        if (segments.length === 0) { u.pathname = '/index.md'; return u.href; }
+
+        const folderName = segments[segments.length - 1];
+        const parentSegments = segments.slice(0, -1);
+        const parentPath = parentSegments.join('/');
+
+        const isVersion = /^\d+\.\d+\.\d+$/.test(folderName);
+        const isLangOrVersion = isVersion || ['en', 'next', 'latest'].includes(folderName);
+        
+        if (isLangOrVersion) { 
+            u.pathname = `/${segments.join('/')}/index.md`; 
+        } else { 
+            u.pathname = parentPath ? `/${parentPath}/${folderName}.md` : `/${folderName}.md`; 
+        }
+        
+        return u.href;
+    }
+
+    async function fetchFlattenedMarkdownForCurrentPage() {
+        const mdUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
+        const res = await fetch(mdUrl, { cache: 'no-cache' });
+        if (!res.ok) throw new Error("Fetch failed");
+        return await res.text();
+    }
+
+    function createCopyPageButton() {
         const container = document.createElement('div');
         container.className = 'copy-page-container';
 
-        // Main Button
         const button = document.createElement('button');
-        button.className = 'copy-page-button md-content__button md-icon';
-        button.type = 'button';
+        button.className = 'copy-page-button md-content__button md-icon'; 
         button.setAttribute('aria-expanded', 'false');
         button.setAttribute('aria-haspopup', 'true');
         button.setAttribute('title', 'Copy page');
         button.innerHTML = Icons.Copy;
 
-        // Backdrop
         const backdrop = document.createElement('div');
         backdrop.className = 'copy-page-backdrop';
 
-        // Menu
         const menu = document.createElement('div');
         menu.className = 'copy-page-menu';
-
-        // Menu Items
         menu.innerHTML = `
             <button class="copy-page-item cp-copy">
                 ${Icons.Copy}
                 <div class="copy-page-item-text">
                     <span class="copy-page-item-title">Copy page</span>
-                    <span class="copy-page-item-desc">Copy page as Markdown for LLMs</span>
+                    <span class="copy-page-item-desc">Copy as Markdown for LLMs</span>
                 </div>
             </button>
             <button class="copy-page-item cp-view">
                 ${Icons.Markdown}
                 <div class="copy-page-item-text">
                     <span class="copy-page-item-title">View as Markdown</span>
-                    <span class="copy-page-item-desc">View this page as plain text</span>
+                    <span class="copy-page-item-desc">View as plain text</span>
                 </div>
             </button>
             <div class="copy-page-divider"></div>
@@ -79,142 +112,83 @@
             </button>
         `;
 
-        // Assemble
-        container.appendChild(button);
-        container.appendChild(backdrop);
+        container.appendChild(button); 
+        container.appendChild(backdrop); 
         container.appendChild(menu);
 
-        // --- Logic ---
-
-        // --- Logic ---
-
         let isOpen = false;
-
         const setOpen = (open) => {
-            isOpen = open;
+            isOpen = open; 
             button.setAttribute('aria-expanded', open.toString());
-
-            if (open) {
-                menu.classList.remove('hidden');
-                menu.style.display = 'block';
-                menu.classList.add('active');
-                backdrop.classList.add('active');
-            } else {
-                menu.classList.remove('active');
-                menu.style.display = 'none'; // Force hide
-                backdrop.classList.remove('active');
+            if (open) { 
+                menu.style.display = 'block'; 
+                menu.classList.add('active'); 
+                backdrop.classList.add('active'); 
+            } else { 
+                menu.classList.remove('active'); 
+                menu.style.display = 'none'; 
+                backdrop.classList.remove('active'); 
             }
         };
 
-        // Global click handler to manage all closing/toggling logic
-        // This avoids race conditions between button click and document click
         const handleGlobalClick = (event) => {
-            // If menu is closed, only the button can open it
             if (!isOpen) {
                 if (button.contains(event.target)) {
                     setOpen(true);
-                    event.stopPropagation(); // Prevent immediate closing if we had other listeners
+                    event.stopPropagation();
                 }
                 return;
             }
-
-            // If menu is open:
-
-            // 1. If clicking the button again, close
             if (button.contains(event.target)) {
                 setOpen(false);
                 return;
             }
-
-            // 2. If clicking inside the menu, do nothing (let menu item handlers work)
             if (menu.contains(event.target)) {
                 return;
             }
-
-            // 3. If clicking outside, close
             setOpen(false);
         };
 
-        // Ensure we don't double-bind
         document.removeEventListener('click', handleGlobalClick);
         document.addEventListener('click', handleGlobalClick);
 
-        // Cleanup logic is hard since we don't know when this component destroys, 
-        // but in this context (docs), it persists. 
-        // We do need to prevent multiple listeners if init runs again.
-        // The init() function checks for .copy-page-container availability, so we are safe from double-init.
-
-
-        // Cleanup routine if needed (though this script runs once per page load)
-
-        const getFullMarkdownUrl = () => {
-            return markdownUrl;
-        };
-
-        const getHtmlUrl = () => {
-            return window.location.href;
-        };
-
-        const getPromptWithMarkdown = () => {
-            const fullUrl = getFullMarkdownUrl();
-            return `Could you read this document about WSO2 Integrator: MI ${fullUrl} so I can ask questions about it?`;
-        };
-
-        const getPromptWithHtml = () => {
-            const fullUrl = getHtmlUrl();
-            return `Could you read this document about WSO2 Integrator: MI ${fullUrl} so I can ask questions about it?`;
+        const getPrompt = () => {
+            const fullUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
+            return `Could you read this document about WSO2 Micro Integrator ${fullUrl} so I can ask questions about it?`;
         };
 
         // Handlers
-        const handleCopyPage = async () => {
+        menu.querySelector('.cp-copy').addEventListener('click', async () => {
             try {
-                const response = await fetch(markdownUrl);
-                if (!response.ok) throw new Error('Failed to fetch');
-                const markdown = await response.text();
+                const markdown = await fetchFlattenedMarkdownForCurrentPage();
                 await navigator.clipboard.writeText(markdown);
-
-                // Feedback
                 const originalTitle = button.getAttribute('title');
                 button.setAttribute('title', 'Copied!');
-
-                setTimeout(() => {
-                    button.setAttribute('title', originalTitle);
-                }, 2000);
+                setTimeout(() => button.setAttribute('title', originalTitle), 2000);
             } catch (err) {
                 console.error('Failed to copy:', err);
             }
             setOpen(false);
-        };
+        });
 
-        const handleViewMarkdown = () => {
-            window.open(markdownUrl, '_blank');
+        menu.querySelector('.cp-view').addEventListener('click', () => {
+            const mdUrl = getFlattenedMarkdownUrlFromHtmlUrl(window.location.href);
+            window.open(mdUrl, '_blank');
             setOpen(false);
+        });
+
+        const aiLinks = { 
+            '.cp-chatgpt': 'https://chat.openai.com/?q=', 
+            '.cp-claude': 'https://claude.ai/new?q=', 
+            '.cp-perplexity': 'https://www.perplexity.ai/search?q=' 
         };
 
-        const handleOpenInChatGPT = () => {
-            // Uses HTML URL
-            window.open(`https://chat.openai.com/?q=${encodeURIComponent(getPromptWithHtml())}`, '_blank');
-            setOpen(false);
-        };
-
-        const handleOpenInClaude = () => {
-            // Uses Markdown URL
-            window.open(`https://claude.ai/new?q=${encodeURIComponent(getPromptWithMarkdown())}`, '_blank');
-            setOpen(false);
-        };
-
-        const handleOpenInPerplexity = () => {
-            // Uses Markdown URL
-            window.open(`https://www.perplexity.ai/?q=${encodeURIComponent(getPromptWithMarkdown())}`, '_blank');
-            setOpen(false);
-        };
-
-        // Attach listeners
-        menu.querySelector('.cp-copy').addEventListener('click', handleCopyPage);
-        menu.querySelector('.cp-view').addEventListener('click', handleViewMarkdown);
-        menu.querySelector('.cp-chatgpt').addEventListener('click', handleOpenInChatGPT);
-        menu.querySelector('.cp-claude').addEventListener('click', handleOpenInClaude);
-        menu.querySelector('.cp-perplexity').addEventListener('click', handleOpenInPerplexity);
+        Object.entries(aiLinks).forEach(([selector, url]) => {
+            menu.querySelector(selector).addEventListener('click', () => {
+                window.open(url + encodeURIComponent(getPrompt()), '_blank', 'noopener,noreferrer');
+                setOpen(false);
+            });
+        });
 
         return container;
     }
@@ -222,72 +196,29 @@
     function init() {
         if (document.querySelector('.copy-page-container')) return;
 
-        // Find Edit button (usually for getting the raw URL)
         const editButton = document.querySelector('.md-content__button.md-icon[href*="/edit/"]');
-
-        // Find View Source button (href usually contains /raw/ or /blob/)
         const viewButton = document.querySelector('.md-content__button.md-icon[href*="/raw/"]') ||
             document.querySelector('.md-content__button.md-icon[href*="/blob/"]');
 
-        let rawUrl;
-        let insertionPoint = null;
+        let insertionPoint = viewButton || editButton;
 
-        // 1. Determine URL
-        if (editButton) {
-            rawUrl = editButton.href
-                .replace('github.com', 'raw.githubusercontent.com')
-                .replace('/edit/', '/')
-                .replace('/blob/', '/');
-        } else if (viewButton) {
-            rawUrl = viewButton.href
-                .replace('github.com', 'raw.githubusercontent.com')
-                .replace('/blob/', '/') // View might be blob, we want raw
-                .replace('/raw/', '/'); // If already raw, check structure
-        } else {
-            // Fallback for homepage
-            const homePageSearch = document.querySelector('.md-home-search-container');
-            if (homePageSearch) {
-                rawUrl = 'https://raw.githubusercontent.com/wso2/docs-mi/main/en/docs/index.md';
-                // Try to find ANY button to append next to
-                insertionPoint = document.querySelector('.md-content__button');
-            }
-        }
+        const btn = createCopyPageButton();
 
-        // 2. Determine Insertion Point
-        // We want DOM order: [Edit, View, Copy] so Visual is [Copy, View, Edit]
-        // So we should insert AFTER 'viewButton' if it exists.
-        // If not, insert AFTER 'editButton'.
-
-        if (viewButton) {
-            insertionPoint = viewButton;
-        } else if (editButton) {
-            insertionPoint = editButton;
-        }
-
-        if (rawUrl) {
-            const btn = createCopyPageButton(rawUrl);
-
-            if (insertionPoint) {
-                // Insert AFTER the insertionPoint
-                if (insertionPoint.nextSibling) {
-                    insertionPoint.parentNode.insertBefore(btn, insertionPoint.nextSibling);
-                } else {
-                    insertionPoint.parentNode.appendChild(btn);
-                }
+        if (insertionPoint) {
+            if (insertionPoint.nextSibling) {
+                insertionPoint.parentNode.insertBefore(btn, insertionPoint.nextSibling);
             } else {
-                // Return to fallback insertion at top logic if no insertion point found
-                const contentInner = document.querySelector('.md-content__inner');
-                if (contentInner) {
-                    // For homepage or pages without other buttons, we want it at the top.
-                    // Especially important for homepage where it defaults to bottom otherwise.
-                    contentInner.insertBefore(btn, contentInner.firstChild);
-                }
+                insertionPoint.parentNode.appendChild(btn);
+            }
+        } else {
+            const contentInner = document.querySelector('.md-content__inner');
+            if (contentInner) {
+                contentInner.insertBefore(btn, contentInner.firstChild);
             }
         }
     }
 
-    // Observer for instant loading
-    const observer = new MutationObserver((mutations) => {
+    const observer = new MutationObserver(() => {
         if (document.querySelector('.md-content') && !document.querySelector('.copy-page-container')) {
             init();
         }

--- a/en/hooks/copy_markdown.py
+++ b/en/hooks/copy_markdown.py
@@ -1,10 +1,19 @@
 import html as html_lib
 import os
+import fnmatch
 
 
 def on_post_build(config, **kwargs):
     docs_dir = config["docs_dir"]
     site_dir = config["site_dir"]
+
+    # Get exclude patterns from the exclude plugin config
+    exclude_patterns = []
+    plugins = config.get("plugins", {})
+    if "exclude" in plugins:
+        exclude_config = plugins["exclude"]
+        if isinstance(exclude_config, dict) and "glob" in exclude_config:
+            exclude_patterns = exclude_config["glob"]
 
     for root, _dirs, files in os.walk(docs_dir):
         for filename in files:
@@ -13,6 +22,15 @@ def on_post_build(config, **kwargs):
 
             src = os.path.join(root, filename)
             rel = os.path.relpath(src, docs_dir)
+
+            # Check if file matches any exclude pattern
+            should_skip = False
+            for pattern in exclude_patterns:
+                if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(rel, f"{pattern}/*"):
+                    should_skip = True
+                    break
+            if should_skip:
+                continue
 
             dst_dir = os.path.join(site_dir, rel)
             # Remove any raw .md file that a previous hook may have created at this path

--- a/en/hooks/copy_markdown.py
+++ b/en/hooks/copy_markdown.py
@@ -1,0 +1,49 @@
+import html as html_lib
+import os
+
+
+def on_post_build(config, **kwargs):
+    docs_dir = config["docs_dir"]
+    site_dir = config["site_dir"]
+
+    for root, _dirs, files in os.walk(docs_dir):
+        for filename in files:
+            if not filename.endswith(".md"):
+                continue
+
+            src = os.path.join(root, filename)
+            rel = os.path.relpath(src, docs_dir)
+
+            dst_dir = os.path.join(site_dir, rel)
+            # Remove any raw .md file that a previous hook may have created at this path
+            if os.path.isfile(dst_dir):
+                os.remove(dst_dir)
+            os.makedirs(dst_dir, exist_ok=True)
+
+            with open(src, encoding="utf-8") as f:
+                content = f.read()
+
+            page = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{html_lib.escape(filename)}</title>
+<style>
+  body {{
+    font-family: monospace;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding: 1.5rem;
+    margin: 0;
+    color: #24292f;
+    background: #ffffff;
+  }}
+</style>
+</head>
+<body>{html_lib.escape(content)}</body>
+</html>"""
+
+            with open(os.path.join(dst_dir, "index.html"), "w", encoding="utf-8") as f:
+                f.write(page)

--- a/en/hooks/copy_md.py
+++ b/en/hooks/copy_md.py
@@ -1,0 +1,90 @@
+import os
+import re
+
+# Global tracker for llms.txt files (if needed)
+ALL_PAGES = []
+
+def promote_headings_outside_fences(content):
+    in_fence = False
+    out = []
+    for line in content.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if not in_fence:
+            # Promote headings for better readability in LLMs
+            line = re.sub(r'^(#{1,6})(\s+)', r'#\1\2', line)
+        out.append(line)
+    return "\n".join(out)
+
+def on_pre_build(config):
+    global ALL_PAGES
+    ALL_PAGES = []
+
+def on_post_page(output, page, config):
+    docs_dir = config['docs_dir']
+    abs_dest = page.file.abs_dest_path
+    
+    # Handle Directory URLs vs Direct File URLs to fix 404s
+    if page.file.src_path == "index.md":
+        # Root index page: index.md -> index.md
+        dest_path = os.path.join(config['site_dir'], "index.md")
+    elif abs_dest.endswith("index.html"):
+        # Subdirectory index page: guides/index.html -> guides.md
+        parent_dir = os.path.dirname(os.path.dirname(abs_dest))
+        folder_name = os.path.basename(os.path.dirname(abs_dest))
+        dest_path = os.path.join(parent_dir, f"{folder_name}.md")
+    else:
+        # Direct file: foo.html -> foo.md
+        dest_path = os.path.splitext(abs_dest)[0] + ".md"
+
+    print(f"DEBUG: Saving flattened markdown for {page.file.src_path} TO {dest_path}")
+
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    
+    # For Micro Integrator, we just use the page markdown directly 
+    # as there are currently no includes or complex redoc tags.
+    content = page.markdown
+    content = promote_headings_outside_fences(content)
+    
+    with open(dest_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+        
+    rel_url = os.path.relpath(dest_path, config['site_dir'])
+    if not any(p["url"] == rel_url for p in ALL_PAGES):
+        ALL_PAGES.append({"title": page.title, "url": rel_url})
+
+def on_post_build(config):
+    # Generating docs for Micro Integrator
+    llms_path = os.path.join(config['site_dir'], "llms.txt")
+    lines = [
+        "# WSO2 Micro Integrator Documentation",
+        "> Optimized for AI agents, LLMs, and developers",
+        "",
+        "## Site Map",
+        "- [Comprehensive file index](./llms-full.txt)"
+    ]
+    with open(llms_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    
+    full_path = os.path.join(config['site_dir'], "llms-full.txt")
+    full_lines = ["# WSO2 Micro Integrator - Full Document Index", ""]
+    for p in sorted(ALL_PAGES, key=lambda x: x['url']):
+        full_lines.append(f"- [{p['title']}](./{p['url']})")
+    with open(full_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(full_lines))
+    print(f"SUCCESS - llms.txt and llms-full.txt generated.")
+
+def on_serve(server, config, builder):
+    """
+    Hook to serve .md files directly during 'mkdocs serve'.
+    This allows localhost:8000/path/to/file.md to work.
+    """
+    from tornado.web import StaticFileHandler
+    
+    # We add a handler that serves any .md file from the built site directory
+    server.app.add_handlers(r".*", [
+        (r"/(.*\.md)", StaticFileHandler, {"path": config['site_dir']})
+    ])
+    return server

--- a/en/hooks/copy_md.py
+++ b/en/hooks/copy_md.py
@@ -1,57 +1,14 @@
 import os
-import re
 
-# Global tracker for llms.txt files (if needed)
+# Global tracker for llms.txt files
 ALL_PAGES = []
-
-def promote_headings_outside_fences(content):
-    in_fence = False
-    out = []
-    for line in content.splitlines():
-        if line.strip().startswith("```"):
-            in_fence = not in_fence
-            out.append(line)
-            continue
-        if not in_fence:
-            # Promote headings for better readability in LLMs
-            line = re.sub(r'^(#{1,6})(\s+)', r'#\1\2', line)
-        out.append(line)
-    return "\n".join(out)
 
 def on_pre_build(config):
     global ALL_PAGES
     ALL_PAGES = []
 
 def on_post_page(output, page, config):
-    docs_dir = config['docs_dir']
-    abs_dest = page.file.abs_dest_path
-    
-    # Handle Directory URLs vs Direct File URLs to fix 404s
-    if page.file.src_path == "index.md":
-        # Root index page: index.md -> index.md
-        dest_path = os.path.join(config['site_dir'], "index.md")
-    elif abs_dest.endswith("index.html"):
-        # Subdirectory index page: guides/index.html -> guides.md
-        parent_dir = os.path.dirname(os.path.dirname(abs_dest))
-        folder_name = os.path.basename(os.path.dirname(abs_dest))
-        dest_path = os.path.join(parent_dir, f"{folder_name}.md")
-    else:
-        # Direct file: foo.html -> foo.md
-        dest_path = os.path.splitext(abs_dest)[0] + ".md"
-
-    print(f"DEBUG: Saving flattened markdown for {page.file.src_path} TO {dest_path}")
-
-    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-    
-    # For Micro Integrator, we just use the page markdown directly 
-    # as there are currently no includes or complex redoc tags.
-    content = page.markdown
-    content = promote_headings_outside_fences(content)
-    
-    with open(dest_path, 'w', encoding='utf-8') as f:
-        f.write(content)
-        
-    rel_url = os.path.relpath(dest_path, config['site_dir'])
+    rel_url = page.file.src_path
     if not any(p["url"] == rel_url for p in ALL_PAGES):
         ALL_PAGES.append({"title": page.title, "url": rel_url})
 
@@ -67,7 +24,7 @@ def on_post_build(config):
     ]
     with open(llms_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
-    
+
     full_path = os.path.join(config['site_dir'], "llms-full.txt")
     full_lines = ["# WSO2 Micro Integrator - Full Document Index", ""]
     for p in sorted(ALL_PAGES, key=lambda x: x['url']):
@@ -75,16 +32,3 @@ def on_post_build(config):
     with open(full_path, "w", encoding="utf-8") as f:
         f.write("\n".join(full_lines))
     print(f"SUCCESS - llms.txt and llms-full.txt generated.")
-
-def on_serve(server, config, builder):
-    """
-    Hook to serve .md files directly during 'mkdocs serve'.
-    This allows localhost:8000/path/to/file.md to work.
-    """
-    from tornado.web import StaticFileHandler
-    
-    # We add a handler that serves any .md file from the built site directory
-    server.app.add_handlers(r".*", [
-        (r"/(.*\.md)", StaticFileHandler, {"path": config['site_dir']})
-    ])
-    return server

--- a/en/hooks/copy_md.py
+++ b/en/hooks/copy_md.py
@@ -8,7 +8,7 @@ def on_pre_build(config):
     ALL_PAGES = []
 
 def on_post_page(output, page, config):
-    rel_url = page.file.src_path
+    rel_url = page.file.src_uri
     if not any(p["url"] == rel_url for p in ALL_PAGES):
         ALL_PAGES.append({"title": page.title, "url": rel_url})
 
@@ -31,4 +31,4 @@ def on_post_build(config):
         full_lines.append(f"- [{p['title']}](./{p['url']})")
     with open(full_path, "w", encoding="utf-8") as f:
         f.write("\n".join(full_lines))
-    print(f"SUCCESS - llms.txt and llms-full.txt generated.")
+    print("SUCCESS - llms.txt and llms-full.txt generated.")

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1251,6 +1251,7 @@ extra_javascript:
   - assets/js/mitheme.js
 hooks:
   - hooks/copy_md.py
+  - hooks/copy_markdown.py
 extra:
   material:
     jinja2content: true

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1249,6 +1249,8 @@ extra_javascript:
   - assets/js/theme.js
   - assets/js/copy-page.js
   - assets/js/mitheme.js
+hooks:
+  - hooks/copy_md.py
 extra:
   material:
     jinja2content: true


### PR DESCRIPTION
## Purpose                           
  Adds a **"View as Markdown"** option to the copy-page toolbar dropdown so readers can view the raw Markdown source of any documentation
  page directly in the browser without triggering a file download.                                                                           
                                                                                                                                             
  ## Goals                                                                                                                                   
  - Allow users to view the raw Markdown source of any page as plain text in the browser.                                                    
  - Work on both `mkdocs serve` (localhost) and GitHub Pages with zero web-server configuration.                                             
  - Never trigger a browser file download prompt.                                                                                            
                                                                                                                                             
  ## Approach                                                                                                                                
  **MkDocs post-build hook (`en/hooks/copy_markdown.py`)**        
  A new `on_post_build` hook walks `docs_dir` and, for every `.md` source file, creates a directory named `<page>.md/` inside `site_dir`     
  containing a minimal `index.html` that renders the escaped Markdown content in a monospace, pre-wrap style. Because the server responds    
  with `Content-Type: text/html` for the `index.html`, browsers render it inline instead of triggering a download — which would happen with a
   raw `.md` file served as `application/octet-stream`.                                                                                      
                                                                  
  **`en/hooks/copy_md.py` cleanup**
  The previous hook wrote raw `.md` files to the same paths now used as directories, and registered a Tornado handler (`on_serve`) that would
   have returned 403 on those directories. Both were removed. Page-info collection for `llms.txt` / `llms-full.txt` is retained, simplified  
  to use `page.file.src_path` directly.
                                                                                                                                             
  **JavaScript (`en/docs/assets/js/copy-page.js`)**                                                                                          
  - The `.cp-view` click handler now navigates the **current tab** (`window.location.href`) to
  `<origin><pathname-without-trailing-slash>.md`, replacing the previous `window.open(..., '_blank')`.                                       
  - `fetchFlattenedMarkdownForCurrentPage` (used by "Copy page" and AI-prompt features) is updated to parse the HTML wrapper with `DOMParser`
   and return `body.textContent`, which decodes HTML entities and restores the original Markdown string.                                     
                                                                  
  URL derivation examples:                                                                                                                   
                                                                  
  | Current page URL | Navigates to |                                                                                                        
  |---|---|                                                       
  | `http://localhost:8000/quick-start-guide/quick-start-guide/` | `http://localhost:8000/quick-start-guide/quick-start-guide.md` |          
  | `https://mi.docs.wso2.com/en/latest/overview/overview/` | `https://mi.docs.wso2.com/en/latest/overview/overview.md` |                    
  | `http://localhost:8000/` | `http://localhost:8000/index.md` |                                                                            
                                                                                                                                             
  The server auto-redirects `.md` → `.md/` (appends trailing slash for the directory) and serves `index.html`. The final address-bar URL will
   have a trailing slash — this is expected and correct.                                                                                     
                                                                                                                                             
  ## User stories                                                 
  - As a developer integrating with WSO2 MI, I want to view the raw Markdown source of a documentation page so I can copy-paste it into my
  own notes or tools without unwanted HTML formatting.                                                                                       
  - As an LLM/AI tool user, I want a direct plain-text view of a documentation page so I can feed it to an AI assistant without
  browser-rendered markup.                                                                                                                   
                                                                  
  ## Release note                                                                                                                            
  Added a "View as Markdown" option to the copy-page toolbar on the documentation site. Clicking it redirects the current tab to a plain-text
   view of the page's raw Markdown source, rendered inline in the browser with no download prompt.                                           
  
  ## Documentation                                                                                                                           
  N/A — this is a documentation site tooling change; it does not affect product documentation content.
                                                                                                                                             
  ## Training
  N/A                                                                                                                                        
                                                                  
  ## Certification
  N/A — no impact on product certification exams.
                                                                                                                                             
  ## Marketing
  N/A                                                                                                                                        
                                                                  
  ## Automation tests
  - Unit tests: N/A — browser-side JavaScript and MkDocs hook; no unit-testable business logic introduced.
  - Integration tests: Manually verified on `mkdocs serve` (localhost) and confirmed the build produces `site/<page>.md/index.html` for every
   source Markdown file. Verified that "View as Markdown" renders inline and "Copy page" still copies clean Markdown text.                   
                                                                                                                                             
  ## Security checks                                                                                                                         
  - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
  - Ran FindSecurityBugs plugin and verified report? **N/A** (no Java code changed)                                                          
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**                                  
                                                                                                                                             
  ## Samples                                                                                                                                 
  N/A                                                             

  ## Related PRs
  N/A
                                                                                                                                             
  ## Migrations (if applicable)
  N/A — static site build change only; no data migration required.                                                                           
                                                                                                                                             
  ## Test environment
  - **OS:** macOS 15 (Darwin 25.3.0)                                                                                                         
  - **Python:** 3.x (MkDocs hook runtime)                                                                                                    
  - **MkDocs:** mkdocs-material                                                                                                              
  - **Browsers tested:** Chrome, Firefox (localhost via `mkdocs serve`)                                                                      
  - **Deployment target:** GitHub Pages                                                                                                      
                                                                                                                                             
  ## Learning                                                                                                                                
  - **MkDocs hooks lifecycle:** Used `on_post_build` (runs once after all pages are built) rather than `on_post_page` (runs per page) because
   the hook reads from `docs_dir` directly and doesn't need per-page context.                                                                
  - **Content-Type problem with raw `.md` files:** Servers (including GitHub Pages and Python's built-in HTTP server) serve `.md` files as
  `application/octet-stream`, triggering a download dialog. Wrapping content in a `<body>` inside an `index.html` directory forces           
  `Content-Type: text/html` with no server configuration.         
  - **`html.escape` + `DOMParser` round-trip:** Python's `html.escape()` encodes `<`, `>`, `&`, `"` so the raw Markdown is safe inside       
  `<body>`. On the JS side, `DOMParser` + `body.textContent` decodes the entities back to the original characters, making the same URL usable
   for both browser viewing and programmatic `fetch()` in the "Copy page" feature.
  - **Tornado `StaticFileHandler` + directories:** Tornado returns HTTP 403 for directory paths, so the existing `on_serve` handler that     
  intercepted `*.md` requests had to be removed to let MkDocs' default handler redirect to the `.md/` directory and serve `index.html`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build now emits mirror HTML pages and two site indexes for direct plain-text/Markdown access.

* **Improvements**
  * "Copy as Markdown" fetches the current page’s Markdown on demand and copies cleaner plain text with temporary "Copied!" feedback.
  * "View as plain text" opens the computed plain-text path; widget is hidden on homepage-like routes and menu wording clarified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->