### PR TITLE
Add OAuth2 authentication parameters for SMTP connections

### DIFF
--- a/en/docs/reference/connectors/email-connector/1.x/email-connector-1.x-config.md
+++ b/en/docs/reference/connectors/email-connector/1.x/email-connector-1.x-config.md
@@ -112,7 +112,7 @@ The following operations allow you to work with the Email Connector. Click an op
         </tr>
     </table>
 
-    The following OAuth2 authentication configurations can be used for IMAP and IMAPS connections. **Note**: These configurations are available from Email connector version 1.1.0 and above.
+    The following OAuth2 authentication configurations can be used for IMAP, IMAPS, and SMTPS connections. **Note**: These configurations are available from Email connector version 1.1.6 and above.
     <table>
         <tr>
             <th>Parameter Name</th>

--- a/en/docs/reference/connectors/email-connector/email-connector-config.md
+++ b/en/docs/reference/connectors/email-connector/email-connector-config.md
@@ -205,6 +205,47 @@ The connection configuration parameters are used to establish a connection with 
             <td>Action to take when the connection pool is exhausted.</td>
             <td>No</td>
         </tr>
+        <tr>
+            <th colspan="3">Oauth2 Authentication</th>
+        </tr>
+        <tr>
+            <td colspan="3">These configurations are available from Email connector version 2.0.3 and above.</td>
+        </tr>
+        <tr>
+            <td>Enable OAuth2</td>
+            <td>Specifies if OAuth2 authentication is required.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Grant Type</td>
+            <td>Type of OAuth2 grant to be used.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Client Id</td>
+            <td>Client ID for OAuth2 authentication.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Client Secret</td>
+            <td>Client Secret for OAuth2 authentication.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Refresh Token</td>
+            <td>Refresh Token for OAuth2 authentication.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Token URL</td>
+            <td>URL to obtain the OAuth2 token.</td>
+            <td>No</td>
+        </tr>
+        <tr>
+            <td>Scope</td>
+            <td>Scope for OAuth2 authentication.</td>
+            <td>No</td>
+        </tr>
     </table>
 
 ??? note "POP3"


### PR DESCRIPTION
This pull request updates the Email Connector documentation to improve and clarify OAuth2 authentication support. The main changes include expanding protocol support for OAuth2 and adding detailed configuration parameters.

**OAuth2 Authentication Enhancements:**

* Updated the documentation to specify that OAuth2 authentication is now supported for IMAP, IMAPS, and SMTPS connections (previously, only IMAP and IMAPS were mentioned).
* Added a new section to the connection configuration parameters table detailing all OAuth2-related configuration options, including enabling OAuth2, grant type, client credentials, token URL, and scope.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4772
