### PR TITLE
Add OAuth2 authentication parameters for SMTP connections

### DIFF
--- a/en/docs/reference/connectors/email-connector/email-connector-config.md
+++ b/en/docs/reference/connectors/email-connector/email-connector-config.md
@@ -112,7 +112,7 @@ The following operations allow you to work with the Email Connector. Click an op
         </tr>
     </table>
 
-    The following OAuth2 authentication configurations can be used for IMAP and IMAPS connections. **Note**: These configurations are available from Email connector version 1.1.0 and above.
+    The following OAuth2 authentication configurations can be used for IMAP, IMAPS and SMTPS connections. **Note**: These configurations are available from Email connector version 1.1.6 and above.
     <table>
         <tr>
             <th>Parameter Name</th>


### PR DESCRIPTION
This pull request updates the Email Connector documentation to improve and clarify OAuth2 authentication support. The main changes include expanding protocol support for OAuth2 and adding detailed configuration parameters.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4772
