### PR TITLE
Fix typo: recieve -> receive in devportal v3 API doc

### DIFF
--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -767,7 +767,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
 
         `X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
 


### PR DESCRIPTION
Fixed spelling on line 770 in devportal-v3.yaml
Changed 'recieve' to 'receive' in API document description.

