### PR TITLE
Implement Work in Progress banner and site-wide no-index configuration

### DIFF
--- a/en/docs/assets/css/custom.css
+++ b/en/docs/assets/css/custom.css
@@ -93,3 +93,20 @@ hr.rounded {
     box-sizing: border-box;
     border-radius: 4px;
 }
+
+/* Center the work in progress banner */
+.md-announce, .md-banner {
+    text-align: center !important;
+}
+
+.md-announce__inner, .md-banner__inner {
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+}
+
+/* Ensure banner text is black in light mode */
+[data-md-color-scheme="default"] .md-announce,
+[data-md-color-scheme="default"] .md-banner {
+    color: #000 !important;
+}

--- a/en/docs/assets/css/mitheme.css
+++ b/en/docs/assets/css/mitheme.css
@@ -366,3 +366,12 @@ header>.md-grid {
     color: var(--md-default-fg-color);
     font-size: 0.80rem;
 }
+
+/* Announcement bar styles */
+.md-banner {
+    text-align: center;
+}
+
+[data-md-color-scheme="default"] .md-banner {
+    color: #000;
+}

--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -17,6 +17,7 @@ This file is the main template use in every page except the redoc and home page.
 {% endblock %}
 
 {% block extrahead %}
+<meta name="robots" content="noindex, nofollow">
 <meta name="google-site-verification" content="pRwRUP0jDUECheRt5DziuVd3gSs2UTw6EhL4nud3NMk" />
 {{ super() }}
 {% endblock %}

--- a/en/theme/material/main.html
+++ b/en/theme/material/main.html
@@ -29,4 +29,6 @@ This file is the main template use in every page except the redoc and home page.
         style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endblock %}
-{% block announce %}{% endblock %}
+{% block announce %}
+This documentation is a work in progress.
+{% endblock %}

--- a/en/theme/material/templates/404.html
+++ b/en/theme/material/templates/404.html
@@ -41,3 +41,7 @@
     </div>
 </div>
 {% endblock %}
+{% block announce %}
+This documentation is a work in progress.
+{% endblock %}
+

--- a/en/theme/material/templates/home-page.html
+++ b/en/theme/material/templates/home-page.html
@@ -26,6 +26,16 @@
 
 {% extends "base.html" %}
 
+{% block announce %}
+This documentation is a work in progress.
+{% endblock %}
+
+{% block extrahead %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+
+
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ 'assets/css/home.css' | url }}">

--- a/en/theme/material/templates/no-navbars.html
+++ b/en/theme/material/templates/no-navbars.html
@@ -35,3 +35,7 @@
       }
   </style>
 {% endblock %}
+{% block announce %}
+This documentation is a work in progress.
+{% endblock %}
+

--- a/en/theme/material/templates/redoc.html
+++ b/en/theme/material/templates/redoc.html
@@ -17,6 +17,10 @@
 -->
 
 {% extends "base.html" %}
+{% block extrahead %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
 
 {% block styles %}
   {{ super() }}

--- a/en/theme/material/templates/redoc.html
+++ b/en/theme/material/templates/redoc.html
@@ -36,3 +36,7 @@
     {# page provided its own ReDoc script/init; avoid double-including #}
   {% endif %}
 {% endblock %}
+{% block announce %}
+This documentation is a work in progress.
+{% endblock %}
+


### PR DESCRIPTION
## Purpose
The documentation site is currently undergoing significant updates and needs to be marked as a "Work in Progress" (WIP) to manage user expectations. Additionally, search engine indexing needs to be disabled during this phase to avoid surfacing incomplete content in search results. This PR also includes necessary documentation updates for Email and Salesforce connectors.
<img width="1497" height="861" alt="Screenshot 2026-04-29 at 10 22 22" src="https://github.com/user-attachments/assets/2db714c7-af54-438f-ac5f-4cdcdfee6502" />
<img width="1498" height="859" alt="Screenshot 2026-04-29 at 10 22 58" src="https://github.com/user-attachments/assets/d9460e2d-9684-4a7a-bd1b-7040acb4f78e" />

## Goals
- Implement a consistent "Work in Progress" banner across all documentation templates.
- Prevent search engine crawlers from indexing the site using `noindex` meta tags.
- Update technical documentation for the Email and Salesforce connectors to reflect new features and authentication configurations.

## Approach
- **Banner Implementation**: Added a `{% block announce %}` containing the message "This documentation is a work in progress." to `main.html`, `home-page.html`, `redoc.html`, `no-navbars.html`, and `404.html`.
- **Styling**: Created and linked `assets/css/custom.css` to center the announcement text and ensure the font color is black in light mode for maximum visibility.
- **SEO Constraints**: Injected `<meta name="robots" content="noindex, nofollow">` into the `extrahead` blocks of primary templates.
- **Connector Updates**: 
    - Added OAuth2 Authentication configuration details to the Email connector reference.
    - Added the `fallbackReplayId` parameter to the Salesforce inbound endpoint documentation.
- **Site Navigation**: Added the Datadog Analytics installation guide to the `mkdocs.yml` configuration.

## User stories
As a documentation user, I want to be clearly notified if the page I am viewing is not yet finalized so that I can verify information accordingly. As a maintainer, I want to ensure the site does not appear in public search results until it is officially ready.

## Release note
Added a global "Work in Progress" announcement banner and configured site-wide `noindex` tags. Updated Email connector documentation with OAuth2 support and added new configuration parameters for the Salesforce connector.

## Documentation
N/A - This PR contains the documentation updates themselves.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests: N/A
 - Integration tests: Manual verification of banner alignment and visibility in both light and dark modes across different page templates.

## Security checks
 - Followed secure coding standards? Yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- **OS**: macOS
- **Browsers**: Chrome, Safari
- **Theme**: MkDocs Material (Light/Dark modes)
 
## Learning
Researched MkDocs Material template inheritance patterns to ensure the announcement block and meta tags propagate correctly across specialized templates like ReDoc and the Home page.