### PR TITLE
Standardize documentation versioning with centralized remote fetching

### DIFF
--- a/en/docs/assets/js/mitheme.js
+++ b/en/docs/assets/js/mitheme.js
@@ -108,14 +108,13 @@ request.onload = function() {
 
               if(versionData) {
                   var liElem = document.createElement('li');
-                  var docLinkType = data.all[key].doc.split(':')[0];
-                  var target = '_self';
-                  var url = data.all[key].doc;
+                  var currentPath = window.location.pathname;
+                  var langPrefixLength = docSetLang ? docSetLang.length + 1 : 0;
+                  var pathWithoutLang = currentPath.substring(langPrefixLength);
+                  if (pathWithoutLang.startsWith('/')) pathWithoutLang = pathWithoutLang.substring(1);
 
-                  var currentPath= window.location.pathname;
-                  // Find the index of '/en/'
-                  var pathWithoutEn = currentPath.substring(4,currentPath.length);
-                  var pathWithoutVersion = pathWithoutEn.substring(pathWithoutEn.indexOf("/"), pathWithoutEn.length)
+                  var firstSlashIndex = pathWithoutLang.indexOf("/");
+                  var pathWithoutVersion = (firstSlashIndex !== -1) ? pathWithoutLang.substring(firstSlashIndex) : "/";
 
                   var versionDoc = data.all[key].doc;
                   var docLinkType = versionDoc.split(':')[0];
@@ -124,9 +123,11 @@ request.onload = function() {
                       // For external links (older versions), go directly to the configured URL
                       url = versionDoc.replace(/\/$/, "") + pathWithoutVersion;
                   } else {
-                      // For relative internal branches (like 'latest')
-                      url = docSetUrl + versionDoc + pathWithoutVersion;
+                      // Use the version number (key) instead of the 'doc' alias
+                      url = docSetUrl + key + pathWithoutVersion;
                   }
+
+
 
 
                   liElem.className = 'md-tabs__item mb-tabs__dropdown';
@@ -178,10 +179,13 @@ request.onload = function() {
           // Current released version update
           document.getElementById('current-version-number').innerHTML =
                   data.current;
+          var docDocLink = docSetUrl + data.current;
+          var docNotesLink = docSetUrl + data.current + '/' + data.all[data.current].notes.split('/').slice(1).join('/');
+
           document.getElementById('current-version-documentation-link')
-                  .setAttribute('href', docSetUrl + data.all[data.current].doc);
+                  .setAttribute('href', docDocLink);
           document.getElementById('current-version-release-notes-link')
-                  .setAttribute('href', docSetUrl + data.all[data.current].notes);
+                  .setAttribute('href', docNotesLink);
 
           // Pre-release version update
           document.getElementById('pre-release-version-documentation-link')

--- a/en/docs/assets/js/mitheme.js
+++ b/en/docs/assets/js/mitheme.js
@@ -113,11 +113,20 @@ request.onload = function() {
                   var url = data.all[key].doc;
 
                   var currentPath= window.location.pathname;
-                     // Find the index of '/en/'
+                  // Find the index of '/en/'
                   var pathWithoutEn = currentPath.substring(4,currentPath.length);
                   var pathWithoutVersion = pathWithoutEn.substring(pathWithoutEn.indexOf("/"), pathWithoutEn.length)
 
-                  url = docSetUrl + key+ pathWithoutVersion;
+                  var versionDoc = data.all[key].doc;
+                  var docLinkType = versionDoc.split(':')[0];
+
+                  if (docLinkType === 'https' || docLinkType === 'http') {
+                      // For external links (older versions), go directly to the configured URL
+                      url = versionDoc.replace(/\/$/, "") + pathWithoutVersion;
+                  } else {
+                      // For relative internal branches (like 'latest')
+                      url = docSetUrl + versionDoc + pathWithoutVersion;
+                  }
 
 
                   liElem.className = 'md-tabs__item mb-tabs__dropdown';
@@ -127,8 +136,10 @@ request.onload = function() {
               }
           });
 
-          document.getElementById('show-all-versions-link')
-              .setAttribute('href', docSetUrl + 'versions');
+          var showAllLink = document.getElementById('show-all-versions-link');
+          if (showAllLink) {
+              showAllLink.setAttribute('href', docSetUrl + 'versions');
+          }
       }
 
       /*

--- a/en/docs/assets/js/mitheme.js
+++ b/en/docs/assets/js/mitheme.js
@@ -103,7 +103,16 @@ request.onload = function() {
        * Appending versions to the version selector dropdown
        */
       if (dropdown){
-          data.list.sort().forEach(function(key, index){
+          data.list.sort(function(a, b) {
+              var aParts = a.split('.');
+              var bParts = b.split('.');
+              for (var i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+                  var aPart = parseInt(aParts[i]) || 0;
+                  var bPart = parseInt(bParts[i]) || 0;
+                  if (aPart !== bPart) return aPart - bPart;
+              }
+              return 0;
+          }).forEach(function(key, index){
               var versionData = data.all[key];
 
               if(versionData) {
@@ -118,6 +127,8 @@ request.onload = function() {
 
                   var versionDoc = data.all[key].doc;
                   var docLinkType = versionDoc.split(':')[0];
+                  var url = '';
+                  var searchAndHash = window.location.search + window.location.hash;
 
                   if (docLinkType === 'https' || docLinkType === 'http') {
                       // For external links (older versions), go directly to the configured URL
@@ -126,6 +137,7 @@ request.onload = function() {
                       // Use the version number (key) instead of the 'doc' alias
                       url = docSetUrl + key + pathWithoutVersion;
                   }
+                  url = url.replace(/\/$/, "") + searchAndHash;
 
 
 
@@ -151,21 +163,28 @@ request.onload = function() {
 
           Object.keys(data.all).forEach(function(key, index){
               if ((key !== data.current) && (key !== data['pre-release'])) {
-                  var docLinkType = data.all[key].doc.split(':')[0];
+                  var doc = data.all[key].doc;
+                  var notes = data.all[key].notes;
                   var target = '_self';
 
-                  if ((docLinkType == 'https') || (docLinkType == 'http')) {
-                      target = '_blank'
+                  if (doc.startsWith('http')) {
+                      target = '_blank';
+                  } else {
+                      doc = (docSetUrl + key + '/' + doc).replace(/([^:]\/)\/+/g, "$1");
+                  }
+
+                  if (!notes.startsWith('http')) {
+                      notes = (docSetUrl + key + '/' + notes).replace(/([^:]\/)\/+/g, "$1");
                   }
 
                   previousVersions.push('<tr>' +
                     '<th>' + key + '</th>' +
                         '<td>' +
-                            '<a href="' + data.all[key].doc + '" target="' +
+                            '<a href="' + doc + '" target="' +
                                 target + '">Documentation</a>' +
                         '</td>' +
                         '<td>' +
-                            '<a href="' + data.all[key].notes + '" target="' +
+                            '<a href="' + notes + '" target="' +
                                 target + '">Release Notes</a>' +
                         '</td>' +
                     '</tr>');

--- a/en/docs/assets/js/mitheme.js
+++ b/en/docs/assets/js/mitheme.js
@@ -77,8 +77,9 @@ for (var i = 0; i < dropdowns.length; i++) {
 };
 
 
-// Reading versions
-
+/*
+ * Reading versions
+ */
 var pageHeader = document.getElementById('page-header');
 var docSetLang = pageHeader.getAttribute('data-lang');
 
@@ -87,134 +88,102 @@ var docSetLang = pageHeader.getAttribute('data-lang');
     docSetLang = docSetLang + '/';
 
 var docSetUrl = window.location.origin + '/' + docSetLang;
-var langRoot = window.location.origin + '/' + docSetLang;
-var activeRoot = window.location.origin + window.location.pathname.substring(0, window.location.pathname.indexOf('/', 4) + 1);
-
-if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-    docSetUrl = window.location.origin + '/en/latest/';
-    activeRoot = window.location.origin + '/en/latest/';
-    langRoot = window.location.origin + '/en/';
-}
-
 var request = new XMLHttpRequest();
 
-request.open('GET', activeRoot +
-    'versions/assets/versions.json', true);
+request.open('GET', 'https://raw.githubusercontent.com/wso2/docs-mi/versions/en/docs/assets/versions.json', true);
 
-request.onload = function () {
-    if (request.status >= 200 && request.status < 400) {
+request.onload = function() {
+  if (request.status >= 200 && request.status < 400) {
 
-        var data = JSON.parse(request.responseText);
-        var dropdown = document.getElementById('version-select-dropdown');
-        var checkVersionsPage = document.getElementById('current-version-stable');
+      var data = JSON.parse(request.responseText);
+      var dropdown =  document.getElementById('version-select-dropdown');
+      var checkVersionsPage = document.getElementById('current-version-stable');
 
+      /*
+       * Appending versions to the version selector dropdown
+       */
+      if (dropdown){
+          data.list.sort().forEach(function(key, index){
+              var versionData = data.all[key];
 
-        // Appending versions to the version selector dropdown
+              if(versionData) {
+                  var liElem = document.createElement('li');
+                  var docLinkType = data.all[key].doc.split(':')[0];
+                  var target = '_self';
+                  var url = data.all[key].doc;
 
-        function compareSemVer(a, b) {
-            // implement a compareSemVer function that splits version strings by '.' and compares each numeric segment
-            var partsA = a.split('.').map(Number);
-            var partsB = b.split('.').map(Number);
-            for (var i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-                var valA = partsA[i] || 0;
-                var valB = partsB[i] || 0;
-                if (valA !== valB) return valA - valB; // Ascending like default sort()
-            }
-            return a.localeCompare(b);
-        }
+                  var currentPath= window.location.pathname;
+                     // Find the index of '/en/'
+                  var pathWithoutEn = currentPath.substring(4,currentPath.length);
+                  var pathWithoutVersion = pathWithoutEn.substring(pathWithoutEn.indexOf("/"), pathWithoutEn.length)
 
-        if (dropdown) {
-            data.list.sort(compareSemVer).forEach(function (key, index) {
-                var versionData = data.all[key];
-
-                if (versionData) {
-                    var liElem = document.createElement('li');
-                    var docLinkType = data.all[key].doc.split(':')[0];
-                    var target = '_self';
-                    var url = data.all[key].doc;
-
-                    var currentPath = window.location.pathname;
-                    // Find the index of '/en/'
-                    var pathWithoutEn = currentPath.substring(4, currentPath.length);
-                    var pathWithoutVersion = pathWithoutEn.substring(pathWithoutEn.indexOf("/"), pathWithoutEn.length);
-
-                    if (docLinkType === 'https' || docLinkType === 'http') {
-                        // For external links (older versions), go directly to the configured URL for that version plus the path
-                        url = data.all[key].doc.replace(/\/$/, "") + pathWithoutVersion;
-                    } else {
-                        // For relative internal branches (like 'latest')
-                        var baseDocUrl = langRoot;
-                        if (baseDocUrl.endsWith('latest/')) {
-                            // Trim trailing 'latest/' so we can properly append relative paths from versions.json
-                            baseDocUrl = baseDocUrl.substring(0, baseDocUrl.length - 7);
-                        }
-                        url = baseDocUrl + data.all[key].doc + pathWithoutVersion;
-                    }
+                  url = docSetUrl + key+ pathWithoutVersion;
 
 
-                    liElem.className = 'md-tabs__item mb-tabs__dropdown';
-                    liElem.innerHTML = '<a href="' + url + '">' + key + '</a>';
+                  liElem.className = 'md-tabs__item mb-tabs__dropdown';
+                  liElem.innerHTML =  '<a href="'+ url+'">' + key + '</a>';
 
-                    dropdown.insertBefore(liElem, dropdown.firstChild);
-                }
-            });
+                  dropdown.insertBefore(liElem, dropdown.firstChild);
+              }
+          });
 
-            document.getElementById('show-all-versions-link')
-                .setAttribute('href', activeRoot + 'versions');
-        }
+          document.getElementById('show-all-versions-link')
+              .setAttribute('href', docSetUrl + 'versions');
+      }
 
+      /*
+       * Appending versions to the version tables in versions page
+       */
+      if (checkVersionsPage){
+          var previousVersions = [];
 
-        // Appending versions to the version tables in versions page
+          Object.keys(data.all).forEach(function(key, index){
+              if ((key !== data.current) && (key !== data['pre-release'])) {
+                  var docLinkType = data.all[key].doc.split(':')[0];
+                  var target = '_self';
 
-        if (checkVersionsPage) {
-            var previousVersions = [];
+                  if ((docLinkType == 'https') || (docLinkType == 'http')) {
+                      target = '_blank'
+                  }
 
-            Object.keys(data.all).forEach(function (key, index) {
-                if ((key !== data.current) && (key !== data['pre-release'])) {
-                    var docLinkType = data.all[key].doc.split(':')[0];
-                    var target = '_self';
-
-                    if ((docLinkType == 'https') || (docLinkType == 'http')) {
-                        target = '_blank'
-                    }
-
-                    previousVersions.push('<tr>' +
-                        '<th>' + key + '</th>' +
+                  previousVersions.push('<tr>' +
+                    '<th>' + key + '</th>' +
                         '<td>' +
-                        '<a href="' + data.all[key].doc + '" target="' +
-                        target + '">Documentation</a>' +
+                            '<a href="' + data.all[key].doc + '" target="' +
+                                target + '">Documentation</a>' +
                         '</td>' +
                         '<td>' +
-                        '<a href="' + data.all[key].notes + '" target="' +
-                        target + '">Release Notes</a>' +
+                            '<a href="' + data.all[key].notes + '" target="' +
+                                target + '">Release Notes</a>' +
                         '</td>' +
-                        '</tr>');
-                }
-            });
+                    '</tr>');
+              }
+          });
 
-            // Past releases update
-            document.getElementById('previous-versions').innerHTML =
-                previousVersions.join(' ');
+          // Past releases update
+          document.getElementById('previous-versions').innerHTML =
+                  previousVersions.join(' ');
 
-            // Current released version update
-            document.getElementById('current-version-number').innerHTML =
-                data.current;
-            document.getElementById('current-version-documentation-link')
-                .setAttribute('href', langRoot + data.all[data.current].doc);
-            document.getElementById('current-version-release-notes-link')
-                .setAttribute('href', langRoot + data.all[data.current].notes);
+          // Current released version update
+          document.getElementById('current-version-number').innerHTML =
+                  data.current;
+          document.getElementById('current-version-documentation-link')
+                  .setAttribute('href', docSetUrl + data.all[data.current].doc);
+          document.getElementById('current-version-release-notes-link')
+                  .setAttribute('href', docSetUrl + data.all[data.current].notes);
 
-            // Pre-release version update
-            document.getElementById('pre-release-version-documentation-link')
-                .setAttribute('href', langRoot + 'next/');
-        }
+          // Pre-release version update
+          document.getElementById('pre-release-version-documentation-link')
+              .setAttribute('href', docSetUrl + 'next/');
+      }
 
-    } else {
-        console.error("We reached our target server, but it returned an error");
-    }
+  } else {
+      console.error("We reached our target server, but it returned an error");
+  }
 };
 
-request.onerror = function () {
+
+request.onerror = function() {
     console.error("There was a connection error of some sort");
 };
 

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -22,7 +22,7 @@
 {% elif "navigation.tabs" not in features %}
 {% set class = class ~ " md-header--shadow" %}
 {% endif %}
-<header class="{{ class }}" data-md-component="header" id="page-header">
+<header class="{{ class }}" data-md-component="header" id="page-header" data-lang="{{ config.theme.language }}">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
     <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}"
       class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">


### PR DESCRIPTION
## Purpose
Resolves issues where the version dropdown was relying on local `versions.json` files that were inconsistent across branches, and addresses broken relative navigation when switching versions.
<img width="1499" height="860" alt="Screenshot 2026-05-01 at 21 45 39" src="https://github.com/user-attachments/assets/b0060257-fb96-4053-935a-73e479a99405" />
<img width="1499" height="854" alt="Screenshot 2026-05-01 at 21 46 12" src="https://github.com/user-attachments/assets/518b8840-a477-4e9b-874b-76afd72622d5" />

## Goals
- Transition the documentation versioning system to a centralized, remote source of truth.
- Ensure that users remain on the same relative page when switching between different product versions.
- Improve the robustness of the version dropdown script by adding necessary DOM guards.

## Approach
- **Remote Version Fetching**: Modified `mitheme.js` to fetch `versions.json` from a centralized GitHub repository (`raw.githubusercontent.com/wso2/docs-mi/versions/en/docs/assets/versions.json`) instead of a local file.
- **Dynamic Path Resolution**: Refactored the URL construction logic in the dropdown to extract the current page path and append it to the selected version's base URL, supporting both internal branch paths (e.g., `latest/`) and external legacy URLs.
- **Header Metadata**: Updated `header.html` to include a `data-lang` attribute, allowing the JavaScript to dynamically detect the current language context for better URL mapping.
- **Defensive Coding**: Added null checks for UI elements like `show-all-versions-link` to prevent script execution errors on pages where these elements might be missing.

## User stories
N/A

## Release note
Updated the documentation version dropdown to fetch versions dynamically from a remote source and improved navigation logic to preserve the current page path during version switches.

## Documentation
N/A. This is a UI/UX improvement for the documentation site itself and does not change the product content.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > Manual verification of version switching across multiple pages (e.g., homepage, deep-link pages) to ensure path persistence.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- MacOS, Chrome 124, MkDocs with Material Theme.

## Learning
Researched dynamic URL manipulation in JavaScript to handle different base URL structures (absolute vs. relative) while maintaining path consistency.