### PR TITLE
Update asb connector receive ops docs

### DIFF
--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2884,10 +2884,7 @@ The following operations require a **MessageReceiver** connection.
     ```
 
 ??? note "receivePayload"
-    Receives only the payload of a message from the configured queue or subscription.
-
-    !!! note
-        This operation can only be used in **Receive and Delete** mode and is not compatible with **Peek Lock** mode.
+    Receives only the payload of a message from the configured queue or subscription. This operation can only be used in **Receive and Delete** mode and is not compatible with **Peek Lock** mode.
 
     <table>
     <tr>

--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2775,14 +2775,7 @@ The following operations require a **MessageReceiver** connection.
         <td>Server Wait Time</td>
         <td>The maximum time (in seconds) the server waits for a message to arrive before returning.</td>
         <td>No</td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td>T</td>
-        <td>Type</td>
-        <td>The expected type of the message payload.</td>
-        <td>No</td>
-        <td>Message</td>
+        <td>60</td>
     </tr>
     <tr>
         <td>deadLettered</td>
@@ -2795,8 +2788,15 @@ The following operations require a **MessageReceiver** connection.
         <th colspan="5">Output</th>
     </tr>
     <tr>
+        <td>returnType</td>
+        <td>Message Body Type</td>
+        <td>Expected type of the message body. Determines how the body is bound when receiving the message. <b>Possible values</b>: <code>json</code>, <code>xml</code>, <code>text</code>.</td>
+        <td>No</td>
+        <td>json</td>
+    </tr>
+    <tr>
         <td>responseVariable</td>
-        <td>Response Variable</td>
+        <td>Output Variable Name</td>
         <td>The name of the variable to store the received message.</td>
         <td>No</td>
         <td>-</td>
@@ -2815,6 +2815,7 @@ The following operations require a **MessageReceiver** connection.
     ```xml
     <asb.receive configKey="asbReceiverConnection">
         <serverWaitTime>60</serverWaitTime>
+        <returnType>json</returnType>
         <responseVariable>asb_receive_1</responseVariable>
         <overwriteBody>false</overwriteBody>
     </asb.receive>
@@ -2885,6 +2886,9 @@ The following operations require a **MessageReceiver** connection.
 ??? note "receivePayload"
     Receives only the payload of a message from the configured queue or subscription.
 
+    !!! note
+        This operation can only be used in **Receive and Delete** mode and is not compatible with **Peek Lock** mode.
+
     <table>
     <tr>
         <th>Parameter Name</th>
@@ -2894,18 +2898,18 @@ The following operations require a **MessageReceiver** connection.
         <th>Default Value</th>
     </tr>
     <tr>
+        <td>T</td>
+        <td>Output Type</td>
+        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content).</td>
+        <td>No</td>
+        <td>json</td>
+    </tr>
+    <tr>
         <td>serverWaitTime</td>
         <td>Server Wait Time</td>
         <td>The maximum time (in seconds) the server waits for a message to arrive.</td>
         <td>No</td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td>T</td>
-        <td>Type</td>
-        <td>The expected type of the message payload.</td>
-        <td>No</td>
-        <td>-</td>
+        <td>60</td>
     </tr>
     <tr>
         <td>deadLettered</td>
@@ -2919,7 +2923,7 @@ The following operations require a **MessageReceiver** connection.
     </tr>
     <tr>
         <td>responseVariable</td>
-        <td>Response Variable</td>
+        <td>Output Variable Name</td>
         <td>The name of the variable to store the received payload.</td>
         <td>No</td>
         <td>-</td>
@@ -2937,6 +2941,7 @@ The following operations require a **MessageReceiver** connection.
 
     ```xml
     <asb.receivePayload configKey="asbReceiverConnection">
+        <T>json</T>
         <serverWaitTime>60</serverWaitTime>
         <responseVariable>asb_receivePayload_1</responseVariable>
         <overwriteBody>false</overwriteBody>

--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2884,7 +2884,7 @@ The following operations require a **MessageReceiver** connection.
     ```
 
 ??? note "receivePayload"
-    Receives only the payload of a message from the configured queue or subscription. This operation can only be used in **Receive and Delete** mode and is not compatible with **Peek Lock** mode.
+    Receives the message from the configured queue or subscription directly bound to the configured output type. This operation can only be used in **Receive and Delete** mode and is not compatible with **Peek Lock** mode.
 
     <table>
     <tr>

--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2914,7 +2914,7 @@ The following operations require a **MessageReceiver** connection.
     <tr>
         <td>T</td>
         <td>Output Type</td>
-        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content).</td>
+        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content). <b>Important</b>: This must match the format in which the message was originally sent. For example, if the message was sent as JSON, you must select <code>json</code> — selecting a different type will result in a binding error.</td>
         <td>No</td>
         <td>json</td>
     </tr>

--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2898,13 +2898,6 @@ The following operations require a **MessageReceiver** connection.
         <th>Default Value</th>
     </tr>
     <tr>
-        <td>T</td>
-        <td>Output Type</td>
-        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content).</td>
-        <td>No</td>
-        <td>json</td>
-    </tr>
-    <tr>
         <td>serverWaitTime</td>
         <td>Server Wait Time</td>
         <td>The maximum time (in seconds) the server waits for a message to arrive.</td>
@@ -2920,6 +2913,13 @@ The following operations require a **MessageReceiver** connection.
     </tr>
     <tr>
         <th colspan="5">Output</th>
+    </tr>
+    <tr>
+        <td>T</td>
+        <td>Output Type</td>
+        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content).</td>
+        <td>No</td>
+        <td>json</td>
     </tr>
     <tr>
         <td>responseVariable</td>

--- a/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
+++ b/en/docs/reference/connectors/asb-connector/asb-connector-reference.md
@@ -2914,7 +2914,7 @@ The following operations require a **MessageReceiver** connection.
     <tr>
         <td>T</td>
         <td>Output Type</td>
-        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content). <b>Important</b>: This must match the format in which the message was originally sent. For example, if the message was sent as JSON, you must select <code>json</code> — selecting a different type will result in a binding error.</td>
+        <td>Type to bind the received message body to. <b>Possible values</b>: <code>json</code> (for JSON payloads), <code>xml</code> (for XML), <code>string</code> (for plain-text/binary content). <b>Important</b>: This must match the format in which the message was originally sent. For example, if the message was sent as JSON, you must select <code>json</code> - selecting a different type will result in a binding error.</td>
         <td>No</td>
         <td>json</td>
     </tr>


### PR DESCRIPTION
## Purpose

Updates the ASB connector reference documentation for the `receive` and `receivePayload` operations to accurately reflect the connector v1.0.2 UI schema.

## Goals

- Correct parameter definitions for `receive` and `receivePayload` operations to match the actual connector v1.0.2 UI schema.
- Improve clarity of descriptions from a user perspective.

## Approach

Compared the UI schema files (`messagereceiver_Receive.json` and `messagereceiver_Receivepayload.json`) from the `asb-connector-1.0.2-jdk17-SNAPSHOT.zip` against the existing documentation and applied the following corrections:

**`receive` operation:**
- Removed the incorrect `T` / Type parameter (not present in v1.0.2 schema for this operation).
- Added `returnType` (Message Body Type) to the Output section with possible values `json`, `xml`, `text` and default `json`.
- Fixed `serverWaitTime` default value from `-` to `60`.
- Updated `responseVariable` display name to `Output Variable Name`.
- Updated sample configuration to include `<returnType>`.

**`receivePayload` operation:**
- Updated description to be clearer from a user perspective.
- Added note that the operation is only compatible with **Receive and Delete** mode, not Peek Lock.
- Corrected `T` display name from `Type` to `Output Type`.
- Updated `T` description with actual possible values (`json`, `xml`, `string`) and a note that the selected type must match the format in which the message was originally sent.
- Fixed `T` default value from `-` to `json`.
- Moved `T` (Output Type) to the Output section.
- Fixed `serverWaitTime` default value from `-` to `60`.
- Updated `responseVariable` display name to `Output Variable Name`.
- Updated sample configuration to include `<T>`.

## User stories

- As a developer using the ASB connector, I want accurate documentation for the `receive` and `receivePayload` operations so that I can configure them correctly without trial and error.
- As a developer using `receivePayload`, I want to know upfront that the output type must match the format the message was sent in, so I avoid runtime binding errors.
- As a developer using `receivePayload`, I want to know that this operation only works in Receive and Delete mode before I design my integration flow.

## Release note

Updated ASB connector reference documentation for `receive` and `receivePayload` operations to reflect the v1.0.2 connector schema - corrected parameters, default values, and improved descriptions.

## Documentation

This PR is itself a documentation change. No additional doc links applicable.

## Training

N/A

## Certification

N/A - documentation-only change with no impact on certification exams.

## Marketing

N/A

## Automation tests

- Unit tests: N/A - documentation-only change.
- Integration tests: N/A - documentation-only change.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (docs only)
- Ran FindSecurityBugs plugin and verified report? N/A (docs only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

Verified locally using MkDocs dev server (`mkdocs serve`).

## Learning

N/A
