### PR TITLE
Visual consistency improvements for MI docs to align with APIM theme

### DIFF
--- a/en/docs/assets/css/custom.css
+++ b/en/docs/assets/css/custom.css
@@ -34,37 +34,52 @@
     border: 1px solid gray;
 }
 
+/* Simple table styling */
 .md-typeset th,
 .md-typeset td {
-    border: 1px solid var(--md-typeset-table-color);
-    border-spacing: 0;
-    border-bottom: none;
-    border-left: none;
-    border-top: none;
+    border: none;
+    border-bottom: 1px solid var(--md-typeset-table-color);
 }
 
 .md-typeset__table {
-    line-height: 1;
+    line-height: 1.5;
 }
 
-.md-typeset__table table:not([class]) {
+.md-typeset table:not([class]) {
     font-size: .74rem;
-    border-right: none;
+    border-collapse: collapse;
+    width: 100%;
 }
 
-.md-typeset__table table:not([class]) td,
-.md-typeset__table table:not([class]) th {
-    padding: 9px;
+.md-typeset table:not([class]) th {
+    padding: 0.6rem 0.8rem;
+    vertical-align: top;
+    background-color: var(--md-code-bg-color);
+    font-weight: 600;
 }
 
-/* light mode alternating table bg colors */
-.md-typeset__table tr:nth-child(2n) {
+.md-typeset table:not([class]) td {
+    padding: 0.6rem 0.8rem;
+    vertical-align: top;
+}
+
+/* light mode alternating table row colors */
+.md-typeset table:not([class]) tbody tr:nth-child(2n) {
     background-color: #f8f8f8;
 }
 
-/* dark mode alternating table bg colors */
-[data-md-color-scheme="slate"] .md-typeset__table tr:nth-child(2n) {
-    background-color: hsla(var(--md-hue), 25%, 25%, 1)
+/* dark mode: no alternating rows — contrast is too harsh */
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tbody tr:nth-child(2n) {
+    background-color: unset;
+}
+
+/* row hover — must come after alternating rule to override it */
+.md-typeset table:not([class]) tbody tr:hover {
+    background-color: #ebebeb;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tbody tr:hover {
+    background-color: rgba(255, 255, 255, 0.07);
 }
 
 
@@ -85,9 +100,19 @@ hr.rounded {
     font-weight: bold;
 }
 
+/* Inline icons used within sentence text */
+.md-typeset .inline-icon {
+    height: 1.5em;
+    width: auto;
+    vertical-align: middle;
+    display: inline-block;
+    border: none;
+    margin: 0 0.2em;
+}
+
 /* Apply white background to images in dark mode ONLY in content area for better visibility of transparent diagrams */
 /* Refined to avoid affecting logos or icons (e.g., enterprise support) that might be in the content */
-[data-md-color-scheme="slate"] .md-content img:not([alt*="Logo" i]):not([alt*="icon" i]):not([alt*="Support" i]) {
+[data-md-color-scheme="slate"] .md-content img:not([alt*="Logo" i]):not([alt*="icon" i]):not([alt*="Support" i]):not(.inline-icon) {
     background-color: #ffffff !important;
     padding: 10px;
     box-sizing: border-box;

--- a/en/docs/assets/css/mitheme.css
+++ b/en/docs/assets/css/mitheme.css
@@ -12,7 +12,7 @@
 }
 
 .md-typeset :not(pre)>code {
-    background: var(--md-md-code-bg-color);
+    background: var(--md-code-bg-color);
     padding: 2px 5px;
     border-radius: 5px;
     font-size: 90%;

--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -765,7 +765,7 @@
 }
 
 .md-typeset {
-  font-size: var(--rem);
+  font-size: 0.8rem;
 }
 
 .md-typeset ul,
@@ -799,8 +799,8 @@
   margin-left: 0;
 }
 
-.md-typeset .admonition > *,
-.md-typeset details > * {
+.md-typeset .admonition > *:not(.admonition-title),
+.md-typeset details > *:not(summary) {
   margin-left: 0;
   margin-right: 0;
 }
@@ -905,6 +905,14 @@
     --md-code-block-radius: .4rem;
 }
 
+/* Light mode overrides for code blocks */
+[data-md-color-scheme=default] {
+    --md-code-fg-color: #1f2024;
+    --md-code-bg-color: #e8e8e8;
+    --md-code-tab-bg-color: #d4d4d4;
+    --md-code-linenos-bg-color: #e0e0e0;
+}
+
 :root, [data-md-color-scheme=slate] {
     /* START OF - Default Material Theme Overrides  */
     --md-default-bg-color: #232327;
@@ -996,6 +1004,10 @@
     color: var(--colors-white);
 }
 
+[data-md-color-scheme=default] .md-typeset .tabbed-labels > label {
+    color: var(--md-code-fg-color);
+}
+
 .md-typeset .highlighttable > tbody > tr + tr > .code > div > pre > code {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
@@ -1013,8 +1025,8 @@
 }
 
 [data-md-color-scheme=default] .md-typeset code {
-    background-color: var(--md-code-fg-color);
-    color: var(--md-code-bg-color);
+    background-color: var(--md-code-bg-color);
+    color: var(--md-code-fg-color);
 }
 
 .md-typeset pre > code {
@@ -1210,7 +1222,7 @@
 
 .md-nav__item {
     margin-top: .8em;
-    font-size: 16px;
+    font-size: 0.7rem;
 }
 
 .md-nav {

--- a/en/docs/assets/lib/highlightjs/styles/custom-highlight-styles.css
+++ b/en/docs/assets/lib/highlightjs/styles/custom-highlight-styles.css
@@ -17,7 +17,7 @@ code.hljs {
 
 /* Light theme - Default */
 [data-md-color-scheme="default"] .hljs {
-  background: #f5f5f5;
+  background: #e8e8e8;
   color: #1f2024;
 }
 
@@ -58,8 +58,11 @@ code.hljs {
 }
 
 [data-md-color-scheme="default"] .hljs-bullet,
-[data-md-color-scheme="default"] .hljs-link,
 [data-md-color-scheme="default"] .hljs-symbol {
+  color: #00b0e8;
+}
+
+[data-md-color-scheme="default"] .hljs-link {
   color: #00b0e8;
   text-decoration: underline;
 }
@@ -113,8 +116,11 @@ code.hljs {
 }
 
 [data-md-color-scheme="slate"] .hljs-bullet,
-[data-md-color-scheme="slate"] .hljs-link,
 [data-md-color-scheme="slate"] .hljs-symbol {
+  color: #4fc1ff;
+}
+
+[data-md-color-scheme="slate"] .hljs-link {
   color: #4fc1ff;
   text-decoration: underline;
 }

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1264,9 +1264,17 @@ extra:
   generator: false
   expanded_navs:
     - title: Get Started
-      options: [verticle-line]
+      options: [verticle-line, no-collapsible]
     - title: Install and Setup
-      options: [verticle-line]
+      options: [verticle-line, divider]
+    - title: Develop
+      options: [verticle-line-only, divider]
+    - title: Learn
+      options: [verticle-line-only, divider]
+    - title: References
+      options: [verticle-line-only, divider]
+    - title: Observe and Manage
+      options: [verticle-line-only, divider]
   home_page_cards:
     - section:
         - title: Get Started

--- a/en/theme/material/assets/css/partials/_typography.css
+++ b/en/theme/material/assets/css/partials/_typography.css
@@ -57,7 +57,7 @@
 }
 
 .md-typeset {
-  font-size: var(--rem);
+  font-size: 0.8rem;
 }
 
 /* List indentation and spacing */
@@ -94,9 +94,9 @@
   margin-left: 0;
 }
 
-/* Admonition content indentation */
-.md-typeset .admonition > *,
-.md-typeset details > * {
+/* Admonition content indentation — exclude title/summary so negative margins stretch it edge-to-edge */
+.md-typeset .admonition > *:not(.admonition-title),
+.md-typeset details > *:not(summary) {
   margin-left: 0;
   margin-right: 0;
 }

--- a/en/theme/material/assets/css/theme.css
+++ b/en/theme/material/assets/css/theme.css
@@ -114,7 +114,7 @@
 /* Light theme overrides for code blocks */
 [data-md-color-scheme=default] {
     --md-code-fg-color: #1f2024;
-    --md-code-bg-color: #f5f5f5;
+    --md-code-bg-color: #e8e8e8;
     --md-code-hl-color: #e8eaf6;
     --md-code-hl-number-color: #b5290a;
     --md-code-hl-special-color: #b5290a;


### PR DESCRIPTION
## Purpose

This PR addresses a series of visual and styling inconsistencies in the MI documentation to better align it with the APIM docs theme.

- Fixed body font size rendering larger than expected due to var(--rem) resolving to 16px
- Fixed nav item font size and added section dividers and vertical line indicators for expanded nav sections
- Configured nav pre-expansion behavior
- Fixed admonition title bar not stretching edge-to-edge in note/tip/info sections. Fixes: https://github.com/wso2/docs-mi/issues/2219
- Fixed code blocks and inline code showing a dark background in light mode
- Fixed YAML list indicator - rendering as = in code blocks
- Fixed table styling - horizontal-only borders, subtle header background, and consistent row hover across all rows
- Fixed inline icons embedded in sentence text rendering at full native size
- Removed high-contrast alternating row colors in dark mode tables

Home page before fixes
<img width="1512" height="861" alt="Screenshot 2026-05-13 at 14 58 21" src="https://github.com/user-attachments/assets/f5a9e082-0c61-4822-93c7-b8ab92cb0236" />

Home page after fixes
<img width="1512" height="860" alt="Screenshot 2026-05-13 at 14 58 13" src="https://github.com/user-attachments/assets/1138fd7e-a273-4477-9329-3fa845ca9db9" />
