### PR TITLE
Correct tab indentation and copy button visibility in light mode

### DIFF
--- a/en/docs/assets/css/theme.css
+++ b/en/docs/assets/css/theme.css
@@ -972,11 +972,11 @@
 .icon-color-4 svg path { fill: var(--icon-color-4-fg) !important; }
 
 [data-md-color-scheme=default] .md-typeset pre > .md-clipboard {
-    color: var(--md-default-bg-color--lightest);
+    color: rgba(0, 0, 0, 0.15);
 }
 
 [data-md-color-scheme=default] .md-typeset pre:hover > .md-clipboard {
-    color: var(--md-default-bg-color--light);
+    color: rgba(0, 0, 0, 0.4);
 }
 
 [data-md-color-scheme=default] .md-typeset pre > .md-clipboard:focus,

--- a/en/docs/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi.md
+++ b/en/docs/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi.md
@@ -136,58 +136,58 @@ OpenTelemetry protocol(OTLP) is a general-purpose telemetry data delivery protoc
 
 Copy the following configuration into the `deployment.toml` file to use OTLP.
 
-    === "Format"
-        ```toml
-        [opentelemetry]
-        enable = true
-        logs = true
-        type = "otlp"
-        url = "endpoint-url"
-    
-        [[opentelemetry.properties]]
-        name = "name-of-the-header"
-        value = "key-value-of-the-header" 
-        ```
-    === "Example"
-        ```toml
-        [opentelemetry]
-        enable = true
-        logs = true
-        type = "otlp"
-        url = "https://otlp.nr-data.net:4317/v1/traces"
-    
-        [[opentelemetry.properties]]
-        name = "api-key"
-        value = "<your-insight-insert-key>" 
-        ```
+=== "Format"
+    ```toml
+    [opentelemetry]
+    enable = true
+    logs = true
+    type = "otlp"
+    url = "endpoint-url"
+
+    [[opentelemetry.properties]]
+    name = "name-of-the-header"
+    value = "key-value-of-the-header" 
+    ```
+=== "Example"
+    ```toml
+    [opentelemetry]
+    enable = true
+    logs = true
+    type = "otlp"
+    url = "https://otlp.nr-data.net:4317/v1/traces"
+
+    [[opentelemetry.properties]]
+    name = "api-key"
+    value = "<your-insight-insert-key>" 
+    ```
 With the above configuration, OTLP uses the gRPC transport by default for exchanging data. This behavior can be changed by setting the value of the configuration `protocol` to `http`.
 
-    === "Format"
-        ```toml
-        [opentelemetry]
-        enable = true
-        logs = true
-        type = "otlp"
-        protocol = "http"
-        url = "endpoint-url"
+=== "Format"
+    ```toml
+    [opentelemetry]
+    enable = true
+    logs = true
+    type = "otlp"
+    protocol = "http"
+    url = "endpoint-url"
 
-        [[opentelemetry.properties]]
-        name = "name-of-the-header"
-        value = "key-value-of-the-header" 
-        ```
-    === "Example"
-        ```toml
-        [opentelemetry]
-        enable = true
-        logs = true
-        type = "otlp"
-        protocol = "http"
-        url = "https://otlp.nr-data.net:4318/v1/traces"
-    
-        [[opentelemetry.properties]]
-        name = "api-key"
-        value = "<your-insight-insert-key>" 
-        ```
+    [[opentelemetry.properties]]
+    name = "name-of-the-header"
+    value = "key-value-of-the-header" 
+    ```
+=== "Example"
+    ```toml
+    [opentelemetry]
+    enable = true
+    logs = true
+    type = "otlp"
+    protocol = "http"
+    url = "https://otlp.nr-data.net:4318/v1/traces"
+
+    [[opentelemetry.properties]]
+    name = "api-key"
+    value = "<your-insight-insert-key>" 
+    ```
 
 !!! note 
     Above example illustrates the OpenTelemetry configurations for NewRelic APM.


### PR DESCRIPTION
## Purpose
- Improve copy button visibility on light mode code blocks
- Correct tab group indentation in OpenTelemetry docs