### PR TITLE
fix: recieves -> receives typo (#2258)

### DIFF
--- a/en/docs/reference/connectors/amazons3-connector/1.x/amazons3-connector-1.x-reference.md
+++ b/en/docs/reference/connectors/amazons3-connector/1.x/amazons3-connector-1.x-reference.md
@@ -113,7 +113,7 @@ To use the Amazon S3 connector, add the <amazons3.init> element in your configur
         </tr>
         <tr>
             <td>expect</td>
-            <td>This header can be used only if a body is sent to not to send the request body until it recieves an acknowledgment.</td>
+            <td>This header can be used only if a body is sent to not to send the request body until it receives an acknowledgment.</td>
             <td>Yes</td>
         </tr>
         <tr>


### PR DESCRIPTION
Fixes #2258.

Corrected 'recieves' to 'receives' across documentation.