### PR TITLE
[MI 440] Add docs related to adding runtime secrets

### DIFF
--- a/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
+++ b/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
@@ -163,3 +163,91 @@ If you start the Micro Integrator as a background job, you will not be able to p
    ```bash
    ./micro-integrator.sh start
    ```
+
+## Managing Secrets at Runtime
+
+The steps above require a server restart whenever a new secret is added or updated. If you need to manage secrets dynamically at runtime, you can store secrets as properties in the registry and read it from there using synapse expressions.
+
+This approach uses the existing [Management API for registry resource properties]({{base_path}}/observe-and-manage/working-with-management-api/#add-properties-to-a-registry-resource) to add or update secrets at runtime, without restarting the server.
+
+!!! note
+    Secrets managed this way are only accessible in synapse configurations via synapse expressions. They cannot be referenced in server configuration files such as `deployment.toml` (e.g., using `$secret{alias}`).
+
+### Step 1: Enable registry-backed vault lookup
+
+Add the following to `deployment.toml` and restart the server **once** to enable the feature:
+
+```toml
+[mediation]
+vault_registry_lookup_enabled = true
+```
+
+Once enabled:
+
+- `wso2:vault-lookup('<alias>')` or `${wso2:vault-lookup('<alias>')}` checks for the secret as a property on `conf:/repository/components/secure-vault` before falling back to `cipher-text.properties`.
+
+### Step 2: Encrypt the secret value
+
+You must store secrets in encrypted form. Use one of the following methods to obtain the ciphertext.
+
+**Option A: Using MI CLI (recommended)**
+
+Initialize the keystore once, pointing to the same JKS keystore configured in MI:
+
+```bash
+mi secret init
+```
+
+Then encrypt the secret interactively. The ciphertext is printed to the console:
+
+```bash
+mi secret create
+```
+
+For more information, see [Encrypting Secrets with MI CLI]({{base_path}}/observe-and-manage/managing-integrations-with-micli/#encrypting-secrets-with-mi-cli).
+
+**Option B: Using the Cipher Tool**
+
+```bash
+sh <MI_HOME>/bin/ciphertool.sh
+```
+
+Copy the encrypted output (ciphertext) from either option.
+
+### Step 3: Obtain a Management API access token
+
+```bash
+curl -X GET "https://localhost:9164/management/login" \
+  -H "Authorization: Basic <base64(username:password)>" -k
+```
+
+Copy the `AccessToken` value from the response.
+
+### Step 4: Add the secret via the Management API
+
+Use the registry resource properties endpoint to store the encrypted value at the secure-vault registry path:
+
+```bash
+curl -X POST \
+  "https://localhost:9164/management/registry-resources/properties?path=registry/config/repository/components/secure-vault" \
+  -H "Authorization: Bearer {AccessToken}" \
+  -H "Content-Type: application/json" \
+  -d '[{"name": "<alias>", "value": "<encrypted_value>"}]' -k
+```
+
+- Replace `<alias>` with the alias you will reference in your synapse configuration (e.g., `myEndpointPassword`).
+- Replace `<encrypted_value>` with the ciphertext from Step 2.
+
+The secret is immediately available — no server restart is required.
+
+### Step 5: Reference the secret in synapse configurations
+
+```xml
+<variable name="password" expression="${wso2-vault('myEndpointPassword')}"/>
+```
+
+If you are using xpath expressions, use the following syntax:
+
+```xml
+<variable name="password" expression="wso2:vault-lookup('myEndpointPassword')"/>
+```

--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -10580,7 +10580,8 @@ statistics.clean_interval = "1000ms"
 stat.tracer.collect_payloads=false
 stat.tracer.collect_mediation_properties=false
 inbound.core_threads = 20
-inbound.max_threads = 100</code></pre>
+inbound.max_threads = 100
+vault_registry_lookup_enabled = false</code></pre>
                     </div>
                 </div>
                 <div class="doc-wrapper">
@@ -10864,6 +10865,27 @@ inbound.max_threads = 100</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>Set this property to true and enable tracing for the required integration artifact to record the following information:&lt;ul&gt;&lt;li&gt;Message context properties.&lt;/li&gt;&lt;li&gt;Message transport-scope properties.&lt;/li&gt;&lt;/ul&gt;</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>vault_registry_lookup_enabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>&quot;true&quot; or &quot;false&quot;</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>When set to <code>true</code>, the <code>wso2:vault-lookup()</code> function checks secrets stored as properties on <code>conf:/repository/components/secure-vault</code> in the registry before falling back to <code>cipher-text.properties</code>. This enables secrets to be added or updated at runtime via the Management API without a server restart. Also protects the secure-vault registry path from being overwritten by CAPP deployments. See <a href="../../install-and-setup/setup/security/encrypting-plain-text/#managing-secrets-at-runtime">Managing Secrets at Runtime</a>.</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Related to https://github.com/wso2/product-integrator-mi/pull/4916, https://github.com/wso2/product-integrator-mi/issues/4903

This PR adds doc related to vault lookup support from registry when vault.registry.lookup.enabled=true in synapse.properties.

Screenshots

<img width="1256" height="785" alt="Screenshot 2026-06-05 at 11 55 32" src="https://github.com/user-attachments/assets/fe7f2ef9-f0ef-415d-8ca4-83a0a708cfd2" />

<img width="1471" height="797" alt="Screenshot 2026-06-05 at 11 55 46" src="https://github.com/user-attachments/assets/9d813c39-c53b-45be-b438-eebff28c93a0" />

<img width="1620" height="827" alt="Screenshot 2026-06-05 at 11 56 34" src="https://github.com/user-attachments/assets/dbc12440-dd71-42a8-9a3f-77deb7361e0e" />
