### PR TITLE
[4.3.0]Add making non-admin user read-only config

### DIFF
--- a/en/docs/install-and-setup/setup/user-stores/managing-users.md
+++ b/en/docs/install-and-setup/setup/user-stores/managing-users.md
@@ -37,7 +37,22 @@ An existing admin user can log in to the Micro Integrator server from the CLI to
 
 ### Non-admin users
 
-Users that do not have admin privileges can access the management API, the CLI, and the ICP server to view and monitor integration artifacts and logs.
+Users without admin privileges can access the management API, the CLI, and the ICP server to update deployed artifacts, and to view and monitor integration artifacts and logs.
+
+#### Restrict non-admin users from updating the deployed artifacts
+To restrict the non-admin users from updating the deployed artifacts through **management API** and **CLI**, you can add the following configuration to the `<MI_HOME>/conf/deployment.toml` file.
+
+```toml
+[user_access]
+make_non_admin_users_read_only = true
+```
+
+To restrict the non-admin users from updating the deployed artifacts with **ICP**, you can add the following configuration to the `<ICP_HOME>/conf/deployment.toml` file.
+
+```toml
+[user_access]
+make_non_admin_users_read_only = true
+```
 
 ## Manage users and roles from the CLI
 

--- a/en/docs/observe-and-manage/working-with-integration-control-plane.md
+++ b/en/docs/observe-and-manage/working-with-integration-control-plane.md
@@ -35,6 +35,14 @@ You can use the ICP server to perform the following administration tasks related
 
     You can enable/disable tracing for the following artifacts: <i>Proxy Services</i>, <i>Endpoints</i>, <i>APIs</i> <i>Sequences</i> and <i>Inbound Endpoints</i>.
 
+    !!! info
+        To restrict the non-admin users in the ICP from updating the deployed artifacts, you can add the following configuration to the `<ICP_HOME>/conf/deployment.toml` file.
+
+        ```toml
+        [user_access]
+        make_non_admin_users_read_only = true
+        ```
+
 -   <b>View registry resources</b>
 
     You can view content, properties, and metadata of each registry resource.


### PR DESCRIPTION
## Purpose
Make non-admin user read-only with the config below.

```
[user_access]
make_non_admin_users_read_only = true
```
Ports: https://github.com/wso2/docs-mi/pull/1071
Fixes: https://github.com/wso2/docs-mi/issues/2305