### PR TITLE
Add VFS locking and timeout guidance to transport docs

### DIFF
--- a/en/docs/install-and-setup/setup/performance-tuning/tuning-the-vfs-transport.md
+++ b/en/docs/install-and-setup/setup/performance-tuning/tuning-the-vfs-transport.md
@@ -42,6 +42,31 @@ Apply the following configurations when you create a proxy service.
         <property name="ClientApiNonBlocking" value="true" scope="axis2" action="remove"/>
         ```
 
+## Disable locking for single-consumer setups
+
+It is not recommended to have multiple consumers accessing the same VFS source folder simultaneously, as this can lead to file processing conflicts.
+
+When a single source folder is accessed by only one consumer, you can disable file locking to improve performance by setting the following parameter in the proxy service:
+
+```xml
+<parameter name="transport.vfs.Locking">disable</parameter>
+```
+
+!!! Note
+    File locking is enabled by default. Only disable it when you are certain that no other consumer accesses the same source folder. See [transport.vfs.Locking]({{base_path}}/reference/synapse-properties/transport-parameters/vfs-transport-parameters/#service-level-parameters) for details.
+
+## Configure the connection timeout
+
+The default socket timeout is not applied for VFS transport connections. You must explicitly configure the `timeout` parameter in the `transport.vfs.FileURI` URL to avoid indefinite connection waits. Specify the timeout value in milliseconds as a query parameter:
+
+```
+ftp://username:password@host/path?timeout=5000
+```
+
+See [VFS URL parameters]({{base_path}}/reference/synapse-properties/transport-parameters/vfs-transport-parameters/#vfs-url-parameters) for details.
+
+## Stream large files
+
 Following is a sample configuration that uses the VFS transport to handle large files:
 
 ```xml

--- a/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/vfs-transport-parameters.md
@@ -208,7 +208,8 @@ See [Creating a Proxy Service]({{base_path}}/develop/creating-artifacts/creating
             transport.vfs.Locking
          </td>
          <td>
-            By default, file locking is enabled in the VFS transport. This parameter lets you configure the locking behavior on a per service basis. You can also disable locking globally by specifying the parameter at the receiver level and selectively enable locking only for a set of services. The setting is enabled by default.
+            By default, file locking is enabled in the VFS transport. This parameter lets you configure the locking behavior on a per service basis. You can also disable locking globally by specifying the parameter at the receiver level and selectively enable locking only for a set of services. The setting is enabled by default.</br></br>
+            <b>Note</b>: It is not recommended to have multiple consumers access the same source folder simultaneously. If a single consumer accesses the source folder, you can set this to <code>disable</code> to turn off locking. See <a href="{{base_path}}/install-and-setup/setup/performance-tuning/tuning-the-vfs-transport/#disable-locking-for-single-consumer-setups">Disable locking for single-consumer setups</a>.
          </td>
       </tr>
       <tr>
@@ -480,7 +481,8 @@ When you use the [transport.vfs.FileURI](#vfs-transport-file_url) parameter, you
            timeout
          </td>
          <td>
-            The connection timeout in milliseconds. Possible value: <code>1000</code>. The default value is <code>5000</code>.
+            The connection timeout in milliseconds. Possible value: <code>1000</code>. The default value is <code>5000</code>.</br></br>
+            <b>Note</b>: The default socket timeout is not applied for VFS transport connections. You must explicitly set this parameter to avoid indefinite connection waits.
          </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Purpose
> Add VFS locking and timeout guidance to VFS transport docs

Fixes: https://github.com/wso2/docs-mi/issues/2326