### PR TITLE
Update SQS connector docs with custom endpoint property #2261

### DIFF
--- a/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
+++ b/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
@@ -71,6 +71,11 @@ To use the Amazon SQS connector, first create the connection with your configura
             <td>The amount of time(in seconds) to wait for the http request to complete before giving up and timing out.</td>
             <td>No</td>
         </tr>
+        <tr>
+            <td>endpoint</td>
+            <td>Optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com). Leave blank to use the default AWS endpoint for the selected region.</td>
+            <td>No</td>
+        </tr>
     </table>
 
     !!! note


### PR DESCRIPTION
## Purpose
Resolves #2261

## Goals
Update the Amazon SQS Connector documentation to include the newly added `Custom Endpoint URL` (`endpoint`) property.

## Approach
Added a new row to the HTML configuration table under the "Connection configurations" section. This documents the `endpoint` parameter, which allows configuring custom VPC interface endpoints (AWS PrivateLink) or custom SQS-compatible hosts.

## User stories
As a DevOps / SRE engineer, I want to configure a custom endpoint for the Amazon SQS connector so that my integration traffic runs securely over private networks (like AWS PrivateLink) or custom local environments.

## Release note
Documentation updated for Amazon SQS Connector 3.x reference to include the `Custom Endpoint URL` configuration parameter.

## Documentation
Link to the modified document: `en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md`

## Training
N/A

## Certification
N/A - This is a documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
- Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
N/A