### PR TITLE
Fix OpenTelemetry tracing documentation formatting (4.3.0)

### DIFF
--- a/en/docs/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi.md
+++ b/en/docs/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi.md
@@ -157,7 +157,7 @@ X-B3-SpanId=f960a2c19e696aa7, X-B3-TraceId=9f3d860546d053aa06d55844a7d209a4}, co
 
 OpenTelemetry protocol(OTLP) is a general-purpose telemetry data delivery protocol used to exchange data between the client and the server. This type can support APMs such as NewRelic, Elastic, etc.
 
-1. Copy the following configuration into the `deployment.toml` file to use OTLP.
+Copy the following configuration into the `deployment.toml` file to use OTLP.
 
     === "Format"
         ```toml
@@ -184,8 +184,8 @@ OpenTelemetry protocol(OTLP) is a general-purpose telemetry data delivery protoc
         value = "<your-insight-insert-key>" 
         ```
 
-    !!! note 
-        Above example illustrates the OpenTelemetry configurations for NewRelic APM.
+!!! note 
+    Above example illustrates the OpenTelemetry configurations for NewRelic APM.
 
 It is recommended to use OTLP to view the traces through NewRelic APM. But still you can use zipkin format traces to view the traces through NewRelic in the following way.
 


### PR DESCRIPTION
## Purpose
Resolves wso2/docs-mi#2247. Ports the formatting fixes from #2246 (merged to `main`) to the `4.3.0` branch.

## Goals
Fix two rendering issues in the *Enabling OTLP Tracing* section of the OpenTelemetry monitoring page:
- A stray `1.` list marker on the "Copy the following configuration ... to use OTLP" step.
- An over-indented `!!! note` admonition (NewRelic APM example) that did not render as an admonition.

## Approach
Applied the same diff as #2246 to the `4.3.0` branch. Formatting only, no content changes.

## Documentation
Documentation-only change. Page: https://mi.docs.wso2.com/en/4.3.0/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi/#enabling-otlp-tracing

## Automation tests
N/A — documentation-only change.

## Security checks
- Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets? yes