### PR TITLE
Update SQS connector documentation for custom endpoint in 4.5.0

### DIFF
--- a/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
+++ b/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
@@ -71,6 +71,11 @@ To use the Amazon SQS connector, first create the connection with your configura
             <td>The amount of time(in seconds) to wait for the http request to complete before giving up and timing out.</td>
             <td>No</td>
         </tr>
+        <tr>
+            <td>endpoint</td>
+            <td>An optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: <code>https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com</code>). Leave this blank to use the default AWS endpoint for the selected region. <b>Note:</b> This option is available only with Amazon SQS Connector v3.0.2 and above.</td>
+            <td>No</td>
+        </tr>
     </table>
 
     !!! note

--- a/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
+++ b/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
@@ -72,8 +72,7 @@ To use the Amazon SQS connector, first create the connection with your configura
             <td>No</td>
         </tr>
         <tr>
-            <td>endpoint</td>
-            <td>An optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: <code>https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com</code>). Leave this blank to use the default AWS endpoint for the selected region. <b>Note:</b> This option is available only with Amazon SQS Connector v3.0.2 and above.</td>
+            <td>An optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: <code>https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com</code>). Omit this parameter to use the default AWS endpoint for the selected region. Note: This option is available only with Amazon SQS connector v3.0.2 and above.</td>
             <td>No</td>
         </tr>
     </table>


### PR DESCRIPTION
## Purpose
Resolves #2266

## Goals
Port the custom endpoint URL (`endpoint`) property documentation for the Amazon SQS Connector from PR #2263 to the `4.5.0` branch.

## Approach
Added a new row to the HTML configuration table under the "Connection configurations" section in the Amazon SQS Connector 3.x reference documentation, documenting the `endpoint` parameter.

## User stories
As a DevOps / SRE engineer, I want to configure a custom endpoint for the Amazon SQS connector so that my integration traffic runs securely over private networks (like AWS PrivateLink) or custom local environments.

## Release note
Documentation updated for Amazon SQS Connector 3.x reference to include the `Custom Endpoint URL` configuration parameter.

## Documentation
`en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
#2263, #2330

## Migrations
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
N/A