### PR TITLE
Port SQS endpoint and S3 forcePathStyle connector docs to main

### DIFF
--- a/en/docs/reference/connectors/amazons3-connector/3.x/amazons3-connector-reference.md
+++ b/en/docs/reference/connectors/amazons3-connector/3.x/amazons3-connector-reference.md
@@ -41,6 +41,18 @@ To use the Amazon S3 connector, `amazons3` connection before carrying out any Am
             <td>The AWS API endpoint hostname to which you need to connect.</td>
             <td>Optional</td>
         </tr>
+        <tr>
+            <td>forcePathStyle</td>
+            <td>
+                Whether to force path-style addressing for S3 objects when using a custom host. This parameter is applicable only when the <code>host</code> parameter is configured.
+                For more information about path-style and virtual-hosted-style access, see
+                <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access" target="_blank">
+                    AWS S3 Path-Style Access Documentation
+                </a>.
+                <br><b>Note:</b> This option is available only with Amazon S3 Connector v3.0.5 and above.
+            </td>
+            <td>Optional</td>
+        </tr>
     </table>
 
     > **Note**: You can either pass credentials within init configuration or set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as environment variables. The AWS SDK uses provider chains to look for AWS credentials in system/user environment variables.

--- a/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
+++ b/en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md
@@ -71,6 +71,12 @@ To use the Amazon SQS connector, first create the connection with your configura
             <td>The amount of time(in seconds) to wait for the http request to complete before giving up and timing out.</td>
             <td>No</td>
         </tr>
+        <tr>
+            <td>endpoint</td>
+            <td>An optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: <code>https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com</code>). Leave this blank to use the default AWS endpoint for the selected region. <b>Note:</b> This option is available only with Amazon SQS Connector v3.0.2 and above.</td>
+            <td>No</td> 
+        </tr>
+
     </table>
 
     !!! note


### PR DESCRIPTION
## Purpose
Resolves #2266

## Goals
Port the following changes to the `main` branch:
- Custom endpoint URL (`endpoint`) property for Amazon SQS Connector from PR #2263
- Path-style addressing (`forcePathStyle`) property for Amazon S3 Connector from PR #2262

## Approach
Added new rows to the HTML configuration tables:
1. `endpoint` parameter in Amazon SQS Connector 3.x reference documentation
2. `forcePathStyle` parameter in Amazon S3 Connector 3.x reference documentation

## User stories
As a DevOps / SRE engineer, I want to configure custom endpoints and path-style addressing for Amazon SQS and S3 connectors so that my integration traffic runs securely over private networks.

## Release note
Documentation updated for Amazon SQS Connector 3.x and Amazon S3 Connector 3.x to include `Custom Endpoint URL` and `forcePathStyle` configuration parameters respectively.

## Documentation
- `en/docs/reference/connectors/amazonsqs-connector/3.x/amazonsqs-connector-3.x-reference.md`
- `en/docs/reference/connectors/amazons3-connector/3.x/amazons3-connector-reference.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
#2262, #2263, #2330

## Migrations
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
N/A