### PR TITLE
Add XML declaration example to XSLT mediator documentation

### DIFF
--- a/en/docs/reference/mediators/xslt-mediator.md
+++ b/en/docs/reference/mediators/xslt-mediator.md
@@ -309,3 +309,32 @@ INFO - LogMediator To: /services/XSLTProxy.XSLTProxyHttpSoap11Endpoint, WSAction
     Then the XSLT transformation happens in memory without writing data to disk. Therefore, performance is increased.
 
     If the input or transformed message size exceeds the value of `<synapse.temp_data_chunk_size>`, the XSLT Mediator creates temporary files at `<MI_HOME>/tmp`. These files are not explicitly deleted by the WSO2 Integrator: MI. The lifecycle of these files is managed by Java's Garbage Collector (GC). When no references to the temporary files remain, they will be expected to be deleted as part of the `java.lang.Object.finalize()` method.
+
+## Example 5 - Adding XML declaration to the output
+
+By default, WSO2 MI does not include the XML declaration (`<?xml version="1.0" encoding="utf-8"?>`) in the output payload. To add the XML declaration to the output, set the `WRITE_XML_DECLARATION` property in the axis2 scope as shown below.
+
+```xml
+<property name="WRITE_XML_DECLARATION" scope="axis2" value="true"/>
+```
+
+**Example:**
+
+```xml
+<sequence name="main">
+    <xslt key="my_transform.xslt"/>
+    <property name="WRITE_XML_DECLARATION" scope="axis2" value="true"/>
+    <respond/>
+</sequence>
+```
+
+The output will include the XML declaration as follows.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Employees>
+    <Employee>
+        <EmployeeID>JOHNDOE1</EmployeeID>
+    </Employee>
+</Employees>
+```


### PR DESCRIPTION
## Purpose
Resolves wso2/docs-mi#1681

## Goals
Add documentation on how to include the XML declaration (`<?xml version="1.0" encoding="utf-8"?>`) in WSO2 MI output payloads using the `WRITE_XML_DECLARATION` axis2 property.

## Approach
Added Example 5 to the XSLT mediator documentation explaining how to use the `WRITE_XML_DECLARATION` property with a code example and expected output.

## User stories
As a WSO2 MI developer, I want to know how to add an XML declaration to my output payload so that downstream systems that require it can process the response correctly.

## Release note
Added documentation for adding XML declaration to output payloads using the `WRITE_XML_DECLARATION` axis2 property in the XSLT mediator docs.

## Documentation
`en/docs/reference/mediators/xslt-mediator.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
Solution referenced from https://stackoverflow.com/questions/13019908/wso2-xml-declaration