### PR TITLE
Fix typo: Correct listener.ora filename in Oracle setup docs

### DIFF
--- a/en/docs/install-and-setup/setup/databases/setting-up-oracle.md
+++ b/en/docs/install-and-setup/setup/databases/setting-up-oracle.md
@@ -38,7 +38,7 @@ Follow the steps below to set up an Oracle database.
     assistant (dbca) or manually.
 2.  Make the necessary changes in the Oracle
     `           tnsnames.ora          ` and
-    `           listner.ora          ` files in order to define
+    `           listener.ora          ` files in order to define
     addresses of the databases for establishing connections to the newly
     created database.
 3.  After configuring the `           .ora          ` files, start the


### PR DESCRIPTION
Corrected the spelling of 'listener.ora' in the documentation.

## Purpose
Resolves: N/A (trivial documentation fix; no related issue)

## Goals
Correct the configuration file name referenced in the Oracle setup documentation so contributors can locate the correct file on their system.

## Approach
Changed `listner.ora` to `listener.ora` in the Oracle database setup guide. Verified against Oracle's official Net Services documentation, which confirms the listener configuration file is named `listener.ora`.

## User stories
N/A

## Release note
Corrected a typo in the Oracle setup documentation: the configuration file `listner.ora` should be `listener.ora`.

## Documentation
en/docs/install-and-setup/setup/databases/setting-up-oracle.md

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A - Single-word text correction; no local build verification needed.
 
## Learning
Verified against Oracle's official Net Services Administrator's Guide on listener.ora.