### PR TITLE
Update setAvoidPermission description in File connector 6 for restriced sftp servers

### DIFF
--- a/en/docs/reference/connectors/file-connector/6.x/file-connector-config.md
+++ b/en/docs/reference/connectors/file-connector/6.x/file-connector-config.md
@@ -623,6 +623,9 @@ There are different connection configurations that can be used for the above pro
 
 ??? note "SFTP"
 
+    !!! note
+        If the SFTP server has disabled the SSH exec channel (i.e., does not allow execution of remote commands) or does not support the `id` command, set **File System Permission Check** (`setAvoidPermission`) to `true`. The connector uses SSH exec to run `id -u` and `id -G` internally to resolve file permissions. If the server restricts exec access, this check will fail. Setting `setAvoidPermission` to `true` bypasses these commands entirely.
+
     <table>
         <tr>
             <th>Parameter Name</th>
@@ -744,8 +747,7 @@ There are different connection configurations that can be used for the above pro
                 Boolean
             </td>
             <td>
-                Set to true if you want to skip the file permission check.</br>
-                Available in file-connector <b>v4.0.9</b> and above.
+                This must be set to <code>true</code> if the SFTP server has disabled the SSH exec channel or does not support the <code>id</code> command.</br></br>
             </td>
             <td>
                 false


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

If the SFTP server has disabled the SSH exec channel (i.e., does not allow execution of remote commands) or does not support the `id` command, set **File System Per
mission Check** (`setAvoidPermission`) to `true`. The connector uses SSH exec to run `id -u` and `id -G` internally to resolve file permissions. If the server restricts exe
c access, this check will fail. Setting `setAvoidPermission` to `true` bypasses these commands entirely.

Related to https://github.com/wso2/wso2-commons-vfs/pull/162

Rendering : 

<img width="1702" height="593" alt="Screenshot 2026-06-30 at 11 39 16" src="https://github.com/user-attachments/assets/941bdf9e-dd36-4ffb-8220-226ea0ed1a52" />
