### PR TITLE
[MI 4.6.0] Add docs related to adding runtime secrets

### DIFF
--- a/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
+++ b/en/docs/install-and-setup/setup/security/encrypting-plain-text.md
@@ -172,3 +172,91 @@ If you start the WSO2 Integrator: MI as a background job, you will not be able t
    ```bash
    ./micro-integrator.sh start
    ```
+
+## Managing Secrets at Runtime
+
+The steps above require a server restart whenever a new secret is added or updated. If you need to manage secrets dynamically at runtime, you can store secrets as properties in the registry and read it from there using synapse expressions.
+
+This approach uses the existing [Management API for registry resource properties]({{base_path}}/observe-and-manage/working-with-management-api/#add-properties-to-a-registry-resource) to add or update secrets at runtime, without restarting the server.
+
+!!! note
+    Secrets managed this way are only accessible in synapse configurations via synapse expressions. They cannot be referenced in server configuration files such as `deployment.toml` (e.g., using `$secret{alias}`).
+
+### Step 1: Enable registry-backed vault lookup
+
+Add the following to `deployment.toml` and restart the server **once** to enable the feature:
+
+```toml
+[mediation]
+vault_registry_lookup_enabled = true
+```
+
+Once enabled:
+
+- `wso2:vault-lookup('<alias>')` or `${wso2:vault-lookup('<alias>')}` checks for the secret as a property on `conf:/repository/components/secure-vault` before falling back to `cipher-text.properties`.
+
+### Step 2: Encrypt the secret value
+
+You must store secrets in encrypted form. Use one of the following methods to obtain the ciphertext.
+
+**Option A: Using MI CLI (recommended)**
+
+Initialize the keystore once, pointing to the same JKS keystore configured in MI:
+
+```bash
+mi secret init
+```
+
+Then encrypt the secret interactively. The ciphertext is printed to the console:
+
+```bash
+mi secret create
+```
+
+For more information, see [Encrypting Secrets with MI CLI]({{base_path}}/observe-and-manage/managing-integrations-with-micli/#encrypting-secrets-with-mi-cli).
+
+**Option B: Using the Cipher Tool**
+
+```bash
+sh <MI_HOME>/bin/ciphertool.sh
+```
+
+Copy the encrypted output (ciphertext) from either option.
+
+### Step 3: Obtain a Management API access token
+
+```bash
+curl -X GET "https://localhost:9164/management/login" \
+  -H "Authorization: Basic <base64(username:password)>" -k
+```
+
+Copy the `AccessToken` value from the response.
+
+### Step 4: Add the secret via the Management API
+
+Use the registry resource properties endpoint to store the encrypted value at the secure-vault registry path:
+
+```bash
+curl -X POST \
+  "https://localhost:9164/management/registry-resources/properties?path=registry/config/repository/components/secure-vault" \
+  -H "Authorization: Bearer {AccessToken}" \
+  -H "Content-Type: application/json" \
+  -d '[{"name": "<alias>", "value": "<encrypted_value>"}]' -k
+```
+
+- Replace `<alias>` with the alias you will reference in your synapse configuration (e.g., `myEndpointPassword`).
+- Replace `<encrypted_value>` with the ciphertext from Step 2.
+
+The secret is immediately available — no server restart is required.
+
+### Step 5: Reference the secret in synapse configurations
+
+```xml
+<variable name="password" expression="${wso2-vault('myEndpointPassword')}"/>
+```
+
+If you are using xpath expressions, use the following syntax:
+
+```xml
+<variable name="password" expression="wso2:vault-lookup('myEndpointPassword')"/>
+```

--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -10648,7 +10648,8 @@ statistics.clean_interval = "1000ms"
 stat.tracer.collect_payloads=false
 stat.tracer.collect_mediation_properties=false
 inbound.core_threads = 20
-inbound.max_threads = 100</code></pre>
+inbound.max_threads = 100
+vault_registry_lookup_enabled = false</code></pre>
                     </div>
                 </div>
                 <div class="doc-wrapper">
@@ -10953,6 +10954,27 @@ inbound.max_threads = 100</code></pre>
                                     </div>
                                     <div class="param-description">
                                         <p>By default, Axis2 spawns a new thread to handle each outgoing message. This is done to enable non-blocking message processing behaviour. But this might exhaust the thread pool and cause erroneous behaviour in guaranteed transaction scenarios. You can use this configuration to disable this behaviour when dealing with queuing transports like JMS. This thread-switching behaviour can also be disabled at the mediation level with the use of a <a href="{{base_path}}/reference/mediators/property-reference/generic-properties/#clientapinonblocking">property</a>.</p>
+                                    </div>
+                                </div>
+                            </div><div class="param">
+                                <div class="param-name">
+                                  <span class="param-name-wrap"> <code>vault_registry_lookup_enabled</code> </span>
+                                </div>
+                                <div class="param-info">
+                                    <div>
+                                        <p>
+                                            <span class="param-type string"> boolean </span>
+                                            
+                                        </p>
+                                        <div class="param-default">
+                                            <span class="param-default-value">Default: <code>false</code></span>
+                                        </div>
+                                        <div class="param-possible">
+                                            <span class="param-possible-values">Possible Values: <code>&quot;true&quot; or &quot;false&quot;</code></span>
+                                        </div>
+                                    </div>
+                                    <div class="param-description">
+                                        <p>When set to <code>true</code>, the <code>wso2:vault-lookup()</code> function checks secrets stored as properties on <code>conf:/repository/components/secure-vault</code> in the registry before falling back to <code>cipher-text.properties</code>. This enables secrets to be added or updated at runtime via the Management API without a server restart. Also protects the secure-vault registry path from being overwritten by CAPP deployments. See <a href="../../install-and-setup/setup/security/encrypting-plain-text/#managing-secrets-at-runtime">Managing Secrets at Runtime</a>.</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Porting https://github.com/wso2/docs-mi/pull/2304

Related to https://github.com/wso2/product-integrator-mi/pull/4916, https://github.com/wso2/product-integrator-mi/issues/4903

This PR adds doc related to vault lookup support from registry when vault.registry.lookup.enabled=true in synapse.properties.

Screenshot:

<img width="1713" height="871" alt="Screenshot 2026-06-30 at 11 49 27" src="https://github.com/user-attachments/assets/3f0577c8-880b-4214-be23-c28b8e3c526d" />

<img width="1681" height="893" alt="Screenshot 2026-06-30 at 11 49 41" src="https://github.com/user-attachments/assets/174c0feb-dc4f-43ec-858c-a010581915b9" />

