### PR TITLE
docs: fix duplicated words in documentation prose

### DIFF
--- a/en/docs/get-started/how-to-guides/ai-data-mapping.md
+++ b/en/docs/get-started/how-to-guides/ai-data-mapping.md
@@ -170,7 +170,7 @@ You can now start configuring the API resource.
 
     <a href="{{base_path}}/assets/img/get-started/how-to-guides/ai-data-mapping/ai-data-mapping-weather-request.png" class="glightbox"><img src="{{base_path}}/assets/img/get-started/how-to-guides/ai-data-mapping/ai-data-mapping-weather-request.png" alt="weather http request" width="30%"></a>
 
-12. Click on the **+** icon in the diagram and search for for the **Datamapper** mediator in the **Mediator Palette**.
+12. Click on the **+** icon in the diagram and search for the **Datamapper** mediator in the **Mediator Palette**.
 
     <a href="{{base_path}}/assets/img/get-started/how-to-guides/ai-data-mapping/ai-data-mapping-data-mapper.png" class="glightbox"><img src="{{base_path}}/assets/img/get-started/how-to-guides/ai-data-mapping/ai-data-mapping-data-mapper.png" alt="search data mapper" width="80%"></a>
 

--- a/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
+++ b/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
@@ -124,7 +124,7 @@ your product by default, be sure to create a new file.
 When this configuration is enabled, all the illegal characters found in
 a payload will be replaced with the actual character that is represented
 by the unicode value that you specify for the parameter. The below
-example uses whitespaces (represented by by the ' \\u0020' unicode
+example uses whitespaces (represented by the ' \\u0020' unicode
 value) to replace illegal characters in payloads.
 
 ```bash

--- a/en/docs/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts.md
+++ b/en/docs/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts.md
@@ -11,7 +11,7 @@ The following are the artifacts used commonly in a WSO2 Integrator: MI deploymen
 
 These are directories in WSO2 Integrator: MI that includes deployable files, which are valid from a specified date and time at runtime.
 
--   `<MI_HOME>/repository/deployment/server` -  Contains Synapse configurations and and other deployment artifacts.
+-   `<MI_HOME>/repository/deployment/server` -  Contains Synapse configurations and other deployment artifacts.
 
 
 ### Persistent Configuration Artifacts

--- a/en/docs/install-and-setup/setup/security/securing-management-api.md
+++ b/en/docs/install-and-setup/setup/security/securing-management-api.md
@@ -111,7 +111,7 @@ path = "/apis"
 
 ## Configuring CORS
 
-CORS is enabled for the management API by default. The default configuration allows all origins (denoted by the `*` symbol). The `Authorization` header is also enabled by default to cater to the functionalities of the the Integration Control Plane.
+CORS is enabled for the management API by default. The default configuration allows all origins (denoted by the `*` symbol). The `Authorization` header is also enabled by default to cater to the functionalities of the Integration Control Plane.
 
 Add the following to the `deployment.toml` file and update the values.
 

--- a/en/docs/observe-and-manage/classic-observability-tcp/starting-tcp-mon.md
+++ b/en/docs/observe-and-manage/classic-observability-tcp/starting-tcp-mon.md
@@ -1,7 +1,7 @@
 # Starting TCPMon
 
 TCPMon is available in the `         MI_HOME/bin        `
-directory of the the WSO2 Integrator: MI distribution. Alternatively,
+directory of the WSO2 Integrator: MI distribution. Alternatively,
 you can download TCPMon from Apache and run the tool.
 
 ## Running TCPMon (from the product distribution)


### PR DESCRIPTION
## Purpose
Fixes doubled word typos found while reviewing the docs mi prose for grammar issues. No related issue filed; this is a small drive by correction.

## Goals
Correct the text so each sentence reads grammatically as intended, with no change to meaning.

## Approach
Manual text fix removed the duplicate word in each of the 5 affected lines. No code, config, or UI changes.

## User stories
N/A

## Release note
Fixed typos (duplicated words) in product documentation.

## Documentation
This PR fixes typos in the following live documentation pages:

- https://mi.docs.wso2.com/en/latest/get-started/how-to-guides/ai-data-mapping/
- https://mi.docs.wso2.com/en/latest/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters/
- https://mi.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/
- https://mi.docs.wso2.com/en/latest/install-and-setup/setup/security/securing-management-api/
- https://mi.docs.wso2.com/en/latest/observe-and-manage/classic-observability-tcp/starting-tcp-mon/

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A (docs only)
 - Ran FindSecurityBugs plugin and verified report? N/A (docs only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A