### PR TITLE
[MI 4.6.0] docs: distinguish between ICP 1.2.0 and ICP 2.0.0 instructions

### DIFF
--- a/en/docs/install-and-setup/install/running-the-integration-control-plane.md
+++ b/en/docs/install-and-setup/install/running-the-integration-control-plane.md
@@ -4,9 +4,17 @@ Follow the steps given below to run the Integration Control Plane.
 
 ## Configure the Integration Control Plane
 
-All configuration lives in `conf/deployment.toml`. The defaults work
-out of the box for local evaluation. ICP will start with the embedded H2
-database, listen on `https://localhost:9446`, and create an `admin` user.
+=== "ICP 2.0.0"
+
+    All configuration lives in `conf/deployment.toml`. The defaults work
+    out of the box for local evaluation. ICP will start with the embedded H2
+    database, listen on `https://localhost:9446`, and create an `admin` user.
+
+=== "ICP 1.2.0"
+
+    All configuration lives in `conf/Config.toml`. The defaults work
+    out of the box for local evaluation. ICP will start with the embedded H2
+    database, listen on `https://localhost:9446`, and create an `admin` user.
 
 ### Essential settings
 
@@ -20,34 +28,67 @@ database, listen on `https://localhost:9446`, and create an `admin` user.
 
 ### Database settings
 
-By default ICP uses an embedded H2 database stored in `bin/database/`. For
-production, switch to PostgreSQL, MySQL, or MSSQL by uncommenting and editing
-the `[icp_server.storage]` section in `deployment.toml`:
+=== "ICP 2.0.0"
 
-```toml
-[icp_server.storage]
-dbType   = "postgresql"
-dbHost   = "db.example.com"
-dbPort   = 5432
-dbName   = "icp_database"
-dbUser   = "icp_user"
-dbPassword = "changeme"
-```
+    By default ICP uses an embedded H2 database stored in `bin/database/`. For
+    production, switch to PostgreSQL, MySQL, or MSSQL by uncommenting and editing
+    the `[icp_server.storage]` section in `deployment.toml`:
 
-A separate credentials database stores user passwords. Configure it with the
-`credentialsDb*` settings if you want credential storage on the same external
-database:
+    ```toml
+    [icp_server.storage]
+    dbType   = "postgresql"
+    dbHost   = "db.example.com"
+    dbPort   = 5432
+    dbName   = "icp_database"
+    dbUser   = "icp_user"
+    dbPassword = "changeme"
+    ```
 
-```toml
-credentialsDbType     = "postgresql"
-credentialsDbHost     = "db.example.com"
-credentialsDbPort     = 5432
-credentialsDbName     = "credentialsdb"
-credentialsDbUser     = "icp_user"
-credentialsDbPassword = "changeme"
-```
+    A separate credentials database stores user passwords. Configure it with the
+    `credentialsDb*` settings if you want credential storage on the same external
+    database:
 
-When using H2 (the default), no database configuration is needed.
+    ```toml
+    credentialsDbType     = "postgresql"
+    credentialsDbHost     = "db.example.com"
+    credentialsDbPort     = 5432
+    credentialsDbName     = "credentialsdb"
+    credentialsDbUser     = "icp_user"
+    credentialsDbPassword = "changeme"
+    ```
+
+    When using H2 (the default), no database configuration is needed.
+
+=== "ICP 1.2.0"
+
+    By default ICP uses an embedded H2 database stored in `database/`. For
+    production, switch to PostgreSQL, MySQL, or MSSQL by uncommenting and editing
+    the `[icp_server.storage]` section in `Config.toml`:
+
+    ```toml
+    [icp_server.storage]
+    dbType   = "postgresql"
+    dbHost   = "db.example.com"
+    dbPort   = 5432
+    dbName   = "icp_database"
+    dbUser   = "icp_user"
+    dbPassword = "changeme"
+    ```
+
+    A separate credentials database stores user passwords. Configure it with the
+    `credentialsDb*` settings if you want credential storage on the same external
+    database:
+
+    ```toml
+    credentialsDbType     = "postgresql"
+    credentialsDbHost     = "db.example.com"
+    credentialsDbPort     = 5432
+    credentialsDbName     = "credentialsdb"
+    credentialsDbUser     = "icp_user"
+    credentialsDbPassword = "changeme"
+    ```
+
+    When using H2 (the default), no database configuration is needed.
 
 ### Observability Settings (OpenSearch)
 
@@ -61,14 +102,27 @@ ICP serves the console and API on port `9446` by default. To expose ICP through 
    self-signed certificate, so configure the proxy to trust it or skip
    verification for the upstream).
 
-2. Tell ICP the external URL so the console can reach the API. Add these to
-   `deployment.toml`:
+2. Tell ICP the external URL so the console can reach the API. Add these settings:
 
-   ```toml
-   backendGraphqlEndpoint      = "https://icp.example.com/graphql"
-   backendAuthBaseUrl           = "https://icp.example.com/auth"
-   backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
-   ```
+    === "ICP 2.0.0"
+
+        Add these to `deployment.toml`:
+
+        ```toml
+        backendGraphqlEndpoint      = "https://icp.example.com/graphql"
+        backendAuthBaseUrl           = "https://icp.example.com/auth"
+        backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
+        ```
+
+    === "ICP 1.2.0"
+
+        Add these to `Config.toml`:
+
+        ```toml
+        backendGraphqlEndpoint      = "https://icp.example.com/graphql"
+        backendAuthBaseUrl           = "https://icp.example.com/auth"
+        backendObservabilityEndpoint = "https://icp.example.com/icp/observability"
+        ```
 
 3. MI runtimes connect to ICP for heartbeats. If they also go through the
    proxy, set `icp_url` in the runtime's `deployment.toml` to the proxy URL:

--- a/en/docs/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp.md
+++ b/en/docs/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp.md
@@ -2,7 +2,15 @@
 
 The built-in user store keeps user credentials — password hashes, salts, and per-user attributes such as failed-login counters — in a dedicated **credentials database**, separate from the main ICP database that holds projects, environments, and integration metadata.
 
-By default both databases use the embedded H2 engine, writing to `<ICP_HOME>/bin/database/`. For production, switch the credentials database to PostgreSQL, MySQL, or MSSQL.
+By default both databases use the embedded H2 engine. For production, switch the credentials database to PostgreSQL, MySQL, or MSSQL.
+
+=== "ICP 2.0.0"
+
+    The default database files are written to `<ICP_HOME>/bin/database/`.
+
+=== "ICP 1.2.0"
+
+    The default database files are written to `<ICP_HOME>/database/`.
 
 
 ## Default Setup (H2)
@@ -24,58 +32,116 @@ Create a dedicated database and user on the database server. The user needs `CRE
 
 ### Step 2 — Initialize the schema
 
-Run the appropriate init script to create the `user_credentials` and `user_attributes` tables and seed the default `admin` user. The scripts are included in the ICP distribution:
+Run the appropriate init script to create the `user_credentials` and `user_attributes` tables and seed the default `admin` user.
 
-<table>
-  <thead>
-    <tr>
-      <th>Database</th>
-      <th>Init script</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>PostgreSQL</td>
-      <td><code>db-scripts/credentials_postgresql_init.sql</code></td>
-    </tr>
-    <tr>
-      <td>MySQL</td>
-      <td><code>db-scripts/credentials_mysql_init.sql</code></td>
-    </tr>
-    <tr>
-      <td>MSSQL</td>
-      <td><code>db-scripts/credentials_mssql_init.sql</code></td>
-    </tr>
-  </tbody>
-</table>
+=== "ICP 2.0.0"
 
-Example for PostgreSQL:
+    The scripts are included in the ICP distribution under the `db-scripts/` directory:
 
-```bash
-psql -h <host> -U <admin_user> -d <credentials_db> \
-  -f db-scripts/credentials_postgresql_init.sql
-```
+    <table>
+      <thead>
+        <tr>
+          <th>Database</th>
+          <th>Init script</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>PostgreSQL</td>
+          <td><code>db-scripts/credentials_postgresql_init.sql</code></td>
+        </tr>
+        <tr>
+          <td>MySQL</td>
+          <td><code>db-scripts/credentials_mysql_init.sql</code></td>
+        </tr>
+        <tr>
+          <td>MSSQL</td>
+          <td><code>db-scripts/credentials_mssql_init.sql</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    Example for PostgreSQL:
+
+    ```bash
+    psql -h <host> -U <admin_user> -d <credentials_db> \
+      -f db-scripts/credentials_postgresql_init.sql
+    ```
+
+=== "ICP 1.2.0"
+
+    The scripts are included in the ICP distribution under the `database/` directory:
+
+    <table>
+      <thead>
+        <tr>
+          <th>Database</th>
+          <th>Init script</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>PostgreSQL</td>
+          <td><code>database/credentials_postgresql_init.sql</code></td>
+        </tr>
+        <tr>
+          <td>MySQL</td>
+          <td><code>database/credentials_mysql_init.sql</code></td>
+        </tr>
+        <tr>
+          <td>MSSQL</td>
+          <td><code>database/credentials_mssql_init.sql</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    Example for PostgreSQL:
+
+    ```bash
+    psql -h <host> -U <admin_user> -d <credentials_db> \
+      -f database/credentials_postgresql_init.sql
+    ```
 
 The init script seeds the `admin` user with a bcrypt hash of the default password `admin`.
 
 !!! warning
     The default `admin` / `admin` credentials are publicly known. Change the password immediately after first login via **Profile** > **Change Password**.
 
-### Step 3 — Configure deployment.toml
+### Step 3 — Configure the configuration file
 
-Add the `credentialsDb*` keys as **top-level entries** in `<ICP_HOME>/conf/deployment.toml`, before any `[section]` header:
+Add the `credentialsDb*` keys as **top-level entries** (before any `[section]` header) to the respective configuration file:
 
-```toml
-credentialsDbType     = "postgresql"
-credentialsDbHost     = "db.example.com"
-credentialsDbPort     = 5432
-credentialsDbName     = "credentials_db"
-credentialsDbUser     = "icp_user"
-credentialsDbPassword = "changeme"
-```
+=== "ICP 2.0.0"
 
-!!! Note
-    These keys must be top-level entries, **not** inside the `[icp_server.storage]` section. The `[icp_server.storage]` section controls the main ICP database (projects, environments, etc.), which is configured independently.
+    Add the settings to `<ICP_HOME>/conf/deployment.toml`:
+
+    ```toml
+    credentialsDbType     = "postgresql"
+    credentialsDbHost     = "db.example.com"
+    credentialsDbPort     = 5432
+    credentialsDbName     = "credentials_db"
+    credentialsDbUser     = "icp_user"
+    credentialsDbPassword = "changeme"
+    ```
+
+    !!! Note
+        These keys must be top-level entries, **not** inside the `[icp_server.storage]` section. The `[icp_server.storage]` section controls the main ICP database (projects, environments, etc.), which is configured independently.
+
+=== "ICP 1.2.0"
+
+    Add the settings to `<ICP_HOME>/conf/Config.toml`:
+
+    ```toml
+    credentialsDbType     = "postgresql"
+    credentialsDbHost     = "db.example.com"
+    credentialsDbPort     = 5432
+    credentialsDbName     = "credentials_db"
+    credentialsDbUser     = "icp_user"
+    credentialsDbPassword = "changeme"
+    ```
+
+    !!! Note
+        These keys must be top-level entries, **not** inside the `[icp_server.storage]` section. The `[icp_server.storage]` section controls the main ICP database (projects, environments, etc.), which is configured independently.
 
 
 <table>

--- a/en/docs/reference/config-catalog-integration-control-plane.md
+++ b/en/docs/reference/config-catalog-integration-control-plane.md
@@ -1,6 +1,8 @@
 # Integration Control Plane Configuration Catalog
 
-All the server-level configurations of your Integration Control Plane can be applied using a single configuration file, which is the `deployment.toml` file (stored in the `ICP_HOME/conf` directory).
+All the server-level configurations of your Integration Control Plane can be applied using a single configuration file:
+* **ICP 2.0.0**: The `deployment.toml` file (stored in the `ICP_HOME/conf` directory).
+* **ICP 1.2.0**: The `Config.toml` file (stored in the `ICP_HOME/conf` directory).
 
 ## Server Settings
 
@@ -30,7 +32,9 @@ All the server-level configurations of your Integration Control Plane can be app
 
 ### Main Database
 
-Configure the main database in the `[icp_server.storage]` section of `<ICP_HOME>/conf/deployment.toml`.
+Configure the main database in the `[icp_server.storage]` section of the configuration file:
+* **ICP 2.0.0**: `<ICP_HOME>/conf/deployment.toml`
+* **ICP 1.2.0**: `<ICP_HOME>/conf/Config.toml`
 
 | Key          | Description                                               |
 | ------------ | --------------------------------------------------------- |
@@ -88,7 +92,9 @@ H2 is suitable for development and testing only.
 
 ### Credentials Database
 
-The default authentication backend stores user credentials in a separate database or schema. These are flat top-level keys in `deployment.toml` (not under any table header).
+The default authentication backend stores user credentials in a separate database or schema. These are flat top-level keys configured in:
+* **ICP 2.0.0**: `deployment.toml` (not under any table header)
+* **ICP 1.2.0**: `Config.toml` (not under any table header)
 
 ```toml
 credentialsDbType = "postgresql"   # h2, postgresql, mysql, or mssql
@@ -108,11 +114,15 @@ credentialsDbPassword = "icp_password"
 | `credentialsDbUser`     | `string` | `"icp_user"`      | Database user                           |
 | `credentialsDbPassword` | `string` | —                 | Database password                       |
 
- Credentials are stored in a dedicated credentials database separate from the main ICP database, configured via `credentialsDbName`, `credentialsDbHost`, and `credentialsDbPort`. For H2, they are stored in `<ICP_HOME>/bin/database/credentials`.
+ Credentials are stored in a dedicated credentials database separate from the main ICP database, configured via `credentialsDbName`, `credentialsDbHost`, and `credentialsDbPort`. For H2, they are stored in:
+ * **ICP 2.0.0**: `<ICP_HOME>/bin/database/credentials`
+ * **ICP 1.2.0**: `<ICP_HOME>/database/credentials`
 
 ## SSO Configurations
 
-Configure Single Sign-On (SSO) using the `[sso]` section of `<ICP_HOME>/conf/deployment.toml`.
+Configure Single Sign-On (SSO) using the `[sso]` section of:
+* **ICP 2.0.0**: `<ICP_HOME>/conf/deployment.toml`
+* **ICP 1.2.0**: `<ICP_HOME>/conf/Config.toml`
 
 ```toml
 [sso]


### PR DESCRIPTION
## Purpose
The Integration Control Plane (ICP) documentation for MI 4.6.0 was previously aligned only with ICP 2.0.0. Since MI 4.6.0 is officially compatible with both ICP 1.2.0 and ICP 2.0.0, the documentation needs to distinguish instructions specific to each version.

Resolves #2345

## Goals
Ensure users running either ICP 1.2.0 or ICP 2.0.0 can find correct setup scripts, configuration files, and default database directories.

## Approach
Used MkDocs content tabs (`pymdownx.tabbed`) to present toggleable version-specific information for:
- Configuration file names (`deployment.toml` for v2.0.0 vs `Config.toml` for v1.2.0)
- Embedded H2 database paths (`bin/database/` for v2.0.0 vs `database/` for v1.2.0)
- Database schema init scripts (`db-scripts/` directory for v2.0.0 vs `database/` directory for v1.2.0)

###  Screenshots:
- **Integration Control Plane Page:**
 <img width="1271" height="800" alt="Screenshot 2026-07-05 032804" src="https://github.com/user-attachments/assets/5b6d211b-629d-4a7c-b6ea-6943a84eaa1d" />

- **Built-in User Store Page:**
 <img width="1271" height="800" alt="Screenshot 2026-07-05 032822" src="https://github.com/user-attachments/assets/0a3125e6-03cf-4245-85f7-ac2f6f70962f" />

- **Configuration Catalog Page:**
 <img width="1271" height="800" alt="Screenshot 2026-07-05 032848" src="https://github.com/user-attachments/assets/c0ce5fd4-70c2-4c33-96de-978418234c14" />

## User stories
As an operator setting up MI 4.6.0 with ICP 1.2.0 or 2.0.0, I want to see the correct file paths and configuration templates for my specific ICP version.

## Release note
N/A

## Documentation
N/A (This is a documentation-only fix).

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A (Documentation changes).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A
