### PR TITLE
Fix typo: paramter -> parameter in docs

### DIFF
--- a/en/docs/develop/using-embedded-micro-integrator.md
+++ b/en/docs/develop/using-embedded-micro-integrator.md
@@ -41,7 +41,7 @@ For some integrations, it is necessary to update the server configurations. For 
 Click the <img src="{{base_path}}/assets/img/integrate/testing-integrations/server-configs-panel-icon.png" width="20"> icon to open the <b>Embedded WSO2 Integrator: MI Configuration</b> dialog box shown below.
 
 !!! Note 
-	You can also paramterize configurations as [environment variables]({{base_path}}/install-and-setup/setup/dynamic-server-configurations) and later [inject environment variables to the embedded WSO2 Integrator: MI](#injecting-environment-variables-to-embedded-micro-integrator).
+	You can also parameterize configurations as [environment variables]({{base_path}}/install-and-setup/setup/dynamic-server-configurations) and later [inject environment variables to the embedded WSO2 Integrator: MI](#injecting-environment-variables-to-embedded-micro-integrator).
 
 <img src="{{base_path}}/assets/img/integrate/testing-integrations/server-configs-panel.png">
 

--- a/en/docs/reference/config-catalog-mi.md
+++ b/en/docs/reference/config-catalog-mi.md
@@ -971,7 +971,7 @@ user.password = "pwd-2"
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Set this paramter to &#39;false&#39; if you want to disable the default file-based user store. This allows you to use an external user store for user authentication in the Management API.</p>
+                                        <p>Set this parameter to &#39;false&#39; if you want to disable the default file-based user store. This allows you to use an external user store for user authentication in the Management API.</p>
                                     </div>
                                 </div>
                             </div>
@@ -2471,7 +2471,7 @@ token_config.size= "2048"
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Set this paramter to &#39;false&#39; if you want to disable JWT authentication for the management API.</p>
+                                        <p>Set this parameter to &#39;false&#39; if you want to disable JWT authentication for the management API.</p>
                                     </div>
                                 </div>
                             </div><div class="param">
@@ -2639,7 +2639,7 @@ path = "/apis"
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Set this paramter to &#39;false&#39; if you want to disable authorization for the management API.</p>
+                                        <p>Set this parameter to &#39;false&#39; if you want to disable authorization for the management API.</p>
                                     </div>
                                 </div>
                             </div>
@@ -2727,7 +2727,7 @@ allowed_headers = "Authorization"</code></pre>
                                         </div>
                                     </div>
                                     <div class="param-description">
-                                        <p>Set this paramter to &#39;false&#39; if you want to disable CORs for the Management API.</p>
+                                        <p>Set this parameter to &#39;false&#39; if you want to disable CORs for the Management API.</p>
                                     </div>
                                 </div>
                             </div><div class="param">


### PR DESCRIPTION
## Purpose
Fix a recurring spelling error where "paramter" was used instead of "parameter" across documentation files, improving readability and professionalism of the docs.

## Goals
Correct all 5 instances of the "paramter" typo across 2 documentation files.

## Approach
Simple find-and-replace of the misspelled word:
- `paramter` → `parameter` (4 instances in config-catalog-mi.md)
- `paramterize` → `parameterize` (1 instance in using-embedded-micro-integrator.md)

### Files changed:
- `en/docs/reference/config-catalog-mi.md` — Lines 974, 2474, 2642, 2730
- `en/docs/develop/using-embedded-micro-integrator.md` — Line 44

## User stories
N/A — Typo fix only.

## Release note
N/A — Documentation typo fix only.

## Documentation
This PR **is** the documentation fix.

## Training
N/A

## Certification
N/A — No impact on certification exams; this is a minor typo correction.

## Marketing
N/A

## Automation tests
N/A — Text-only change, no code affected.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (documentation only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A — Documentation change only.

## Learning
N/A
