### PR TITLE
Port RabbitMQ URL placeholder description and custom builders/formatters doc to 4.4.0

### DIFF
--- a/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
+++ b/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
@@ -242,3 +242,27 @@ class="org.apache.axis2.transport.http.HTMLMessageFormatter"
 ```
 
 The class name used in the above line should be the name used for the class when writing the formatter.
+
+## Configuring custom builders/formatters in blocking mode
+
+The `custom_message_builders` and `custom_message_formatters` configurations shown above apply to non-blocking transports.
+
+When the WSO2 Integrator: MI runs in blocking mode, use the following configurations instead.
+
+### Custom message builders (Blocking mode)
+
+```toml
+[[blocking.custom_message_builders]]
+content_type = "<content_type>"
+class = "<message_builder_class>"
+```
+
+### Custom message formatters (Blocking mode)
+
+```toml
+[[blocking.custom_message_formatters]]
+content_type = "<content_type>"
+class = "<message_formatter_class>"
+```
+
+These configurations function similarly to their non-blocking equivalents, but are applied only when the WSO2 Integrator: MI uses blocking transport.

--- a/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
+++ b/en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md
@@ -247,7 +247,7 @@ The class name used in the above line should be the name used for the class when
 
 The `custom_message_builders` and `custom_message_formatters` configurations shown above apply to non-blocking transports.
 
-When the WSO2 Integrator: MI runs in blocking mode, use the following configurations instead.
+When the WSO2 Micro Integrator runs in blocking mode, use the following configurations instead.
 
 ### Custom message builders (Blocking mode)
 
@@ -265,4 +265,4 @@ content_type = "<content_type>"
 class = "<message_formatter_class>"
 ```
 
-These configurations function similarly to their non-blocking equivalents, but are applied only when the WSO2 Integrator: MI uses blocking transport.
+These configurations function similarly to their non-blocking equivalents, but are applied only when the WSO2 Micro Integrator uses blocking transport.

--- a/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
@@ -229,6 +229,10 @@ In your integration solution, the following RabbitMQ send parameters can be spec
     <th>Description</th>
   </tr>
   <tr>
+    <td>placeholder</td>
+    <td>Specifies the routing key to use when both rabbitmq.queue.name and rabbitmq.queue.routing.key query parameters are not defined. If both parameters are provided, this path value is not used for routing and can be omitted from the URI.</td>
+  </tr>
+  <tr>
     <td>rabbitmq.server.host.name</td>
     <td>Host name of the server.</td>
   </tr>

--- a/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
+++ b/en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md
@@ -204,6 +204,11 @@ To enable SSL support in RabbitMQ, you need to configure the following paramet
 
 In your integration solution, the following RabbitMQ send parameters can be specified in the **Address URL** that you specify in your [Endpoint artifact]({{base_path}}/develop/creating-artifacts/creating-endpoints).
 
+**Format of the Address URL**:
+
+```
+rabbitmq:/<placeholder>?<query-parameter-name1>=<query-parameter-value1>&amp;<query-parameter-name2>=<query-parameter-value2>
+```
 **Example**:
 
 -   Design view of an address endpoint in WSO2 Integration Studio:


### PR DESCRIPTION
## Purpose
Resolves #1884

## Goals
Port the RabbitMQ URL placeholder description and custom builders/formatters documentation updates from PR #1870 to the 4.4.0 branch.

## Approach
1. Added the `placeholder` parameter row to the RabbitMQ transport parameters table in the sending messages section.
2. Added a new "Configuring custom builders/formatters in blocking mode" section to the message builders and formatters documentation.

## User stories
As a WSO2 MI developer, I want to understand the RabbitMQ URL placeholder parameter and how to configure custom message builders/formatters in blocking mode so that I can properly configure my integration.

## Release note
Documentation updated to include the RabbitMQ URL placeholder parameter description and custom builders/formatters configuration for blocking mode transport.

## Documentation
- `en/docs/install-and-setup/setup/message-builders-formatters/message-builders-and-formatters.md`
- `en/docs/reference/synapse-properties/transport-parameters/rabbitmq-transport-parameters.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
#1870

## Migrations
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
N/A