### PR TITLE
Add coordinated task monitoring feature documentation

### DIFF
--- a/en/docs/install-and-setup/setup/feature-configs/configuring-task-monitoring.md
+++ b/en/docs/install-and-setup/setup/feature-configs/configuring-task-monitoring.md
@@ -1,0 +1,108 @@
+# Configure Coordinated Task Monitoring
+
+In a clustered WSO2 Integrator: MI deployment that uses [RDBMS-based coordination]({{base_path}}/install-and-setup/setup/deployment/deploying-wso2-mi/#cluster-coordination), every coordinated task (a scheduled trigger or a message processor) is expected to run on exactly **one** node at a time. **Coordinated task monitoring** lets you verify that this is actually the case: it records which node each coordinated task is running on, detects when the same task ends up running on more than one node, exposes this information through the [Management API]({{base_path}}/observe-and-manage/working-with-management-api/#get-task-status), and writes log alerts you can hook into existing log-based monitoring.
+
+The feature is **disabled by default**, and it is strictly an observer — enabling it never changes how tasks are scheduled or assigned.
+
+## What this feature does
+
+Certain failure patterns — for example, a node with a misconfigured heartbeat interval evicting another node that is still alive — can silently leave the same coordinated task running on two nodes at once, causing duplicate message processing. Without this feature, the only way to notice is to compare application-level side effects across nodes.
+
+When coordinated task monitoring is enabled:
+
+- Every node periodically records the coordinated tasks it is **actually running** into the coordination database (the `RUNNING_TASK_OBSERVATION` table).
+- The leader node continuously cross-checks these observations and records every duplication episode — including short-lived ones — with its duration and severity (the `TASK_DUPLICATION_EVENT` table).
+- The `GET /management/task-status` Management API resource lets you query the live task placement, check for live duplicates, and browse the duplication history.
+- The leader node logs a `WARN` when a duplication is **detected** or **cleared**, and an `ERROR` when it is **sustained**, so existing log alerting catches the problem without anyone polling the API.
+
+## Step 1 - Create the monitoring tables
+
+Run the matching script against your **coordination database** (the database configured as the `WSO2_COORDINATION_DB` datasource):
+
+```text
+<MI_HOME>/dbscripts/<DB_TYPE>/<DB_TYPE>_task_monitoring.sql
+```
+
+Scripts are provided for `mysql`, `mssql`, `oracle`, `oracle-rac`, `postgres`, and `db2`. Each script creates the two monitoring tables:
+
+- `RUNNING_TASK_OBSERVATION`
+- `TASK_DUPLICATION_EVENT`
+
+!!! Note
+    On MySQL, the coordination database must use the `latin1` character set — the `VARCHAR(512)` composite primary key exceeds the InnoDB index key limit under MySQL 8's default `utf8mb4`. This is the same requirement that applies to the base cluster coordination script.
+
+## Step 2 - Enable the feature
+
+Add the following to `<MI_HOME>/conf/deployment.toml` on **every node**, then restart the nodes:
+
+```toml
+[task_handling]
+enable_task_monitoring = true
+```
+
+While the flag is not set, the feature is fully inert: nothing is written to the monitoring tables, and every `task-status` view responds with `"taskMonitoringEnabled": false`.
+
+!!! Note
+    Enable the feature on all nodes in the cluster. A node that does not have the flag set never reports its running tasks, so it is invisible to the monitor and duplications involving that node cannot be detected.
+
+## Step 3 - Query task status
+
+Use the `GET /management/task-status` resource of the Management API. The database-backed views read the shared coordination database, so you can query **any** node and get the cluster-wide answer.
+
+First [get a JWT token]({{base_path}}/observe-and-manage/working-with-management-api/#getting-a-jwt-token), then invoke the resource:
+
+```bash
+curl -X GET "https://localhost:9164/management/task-status?view=duplicates" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+```
+
+| Resource | Shows |
+|----------|-------|
+| `/task-status` | Which coordinated task runs on which node (cluster-wide). |
+| `/task-status?node={nodeId},{nodeId}` | The same view, filtered to specific node(s). |
+| `/task-status?name={taskName}` | Where one task runs, a `duplicate` flag, and the last observed time. |
+| `/task-status?view=duplicates` | Tasks running on two or more nodes **right now** (`"healthy": true` means none). |
+| `/task-status?view=history` | Forensic episode log — every past duplication with severity and duration. Add `&name={taskName}` to filter. |
+| `/task-status?scope=local` | The queried node's own in-memory task set. Reads no database, so it keeps answering during a coordination database outage — query each node and compare. |
+
+For example, a healthy cluster responds to `?view=duplicates` with:
+
+```json
+{
+    "duplicates": [],
+    "healthy": true,
+    "coordinationDbAvailable": true
+}
+```
+
+and a cluster with a live duplication responds with:
+
+```json
+{
+    "duplicates": [
+        {
+            "nodes": ["node", "node1"],
+            "taskName": "SampleScheduledTask"
+        }
+    ],
+    "healthy": false,
+    "coordinationDbAvailable": true
+}
+```
+
+See [GET TASK STATUS]({{base_path}}/observe-and-manage/working-with-management-api/#get-task-status) for the complete resource reference with sample responses for every view.
+
+## Log-based alerting
+
+The leader node logs every duplication state transition, so you do not need to poll the API to be alerted:
+
+- `WARN` — `Coordinated task duplication DETECTED` / `Coordinated task duplication CLEARED`
+- `ERROR` — `Coordinated task duplication SUSTAINED` (the duplication persisted beyond roughly twice the cluster heartbeat-retry interval)
+
+Point your existing log alerting at the `ERROR` line to catch sustained duplications automatically.
+
+## Behavior notes
+
+- Only **coordinated** tasks are monitored. On a standalone (non-clustered) server, the resource responds with `"coordinationEnabled": false`.
+- Timestamps in API responses are ISO-8601 in **UTC** (note the trailing `Z`).
+- During a coordination database outage, the database-backed views degrade explicitly — they return `"coordinationDbAvailable": false` instead of a false `"healthy": true`. Use `?scope=local` against each node in that state.
+- A normal task failover (a node shutting down and its tasks moving to another node) is **not** reported as a duplication — observations are aged out using a freshness window derived from the cluster heartbeat-retry interval. Keep the heartbeat interval at or above its default so this window behaves as intended.

--- a/en/docs/observe-and-manage/working-with-management-api.md
+++ b/en/docs/observe-and-manage/working-with-management-api.md
@@ -1190,6 +1190,151 @@ The management API has multiple resources to provide information regarding the d
 		{"message":"HelloScheduledTask : is deactivated"}
 	    ```
 
+### GET TASK STATUS
+
+-	**Resource**: `/task-status`
+
+	**Description**: Retrieves which node of the cluster each coordinated task is currently running on. This resource is available when [coordinated task monitoring]({{base_path}}/install-and-setup/setup/feature-configs/configuring-task-monitoring) is enabled — while the feature is disabled, every view responds with `"taskMonitoringEnabled": false`. All views except `?scope=local` read the shared coordination database, so querying any one node returns the cluster-wide answer.
+
+	**Example**:
+
+    === "Request"
+	    ```bash  
+	    curl -X GET "https://localhost:9164/management/task-status" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+	    ```
+    === "Response"          
+	    ```bash  
+	    {
+	        "nodes": [
+	            {
+	                "nodeId": "node",
+	                "tasks": [
+	                    "SampleScheduledTask",
+	                    "MSMP_sampleMessageProcessor_0"
+	                ]
+	            },
+	            {
+	                "nodeId": "node1",
+	                "tasks": [
+	                    "AnotherScheduledTask"
+	                ]
+	            }
+	        ],
+	        "coordinationDbAvailable": true
+	    }
+	    ```
+
+-	**Resource**: `/task-status?node={nodeId},{nodeId}`
+
+	**Description**: The same view, filtered to the specified node(s). A requested node that is running no coordinated tasks is listed with an empty `tasks` array.
+
+-	**Resource**: `/task-status?name={taskName}`
+
+	**Description**: Retrieves where the specified task is running, together with a `duplicate` flag and the last-observed time (ISO-8601, UTC).
+
+	**Example**:
+
+    === "Request"
+	    ```bash  
+	    curl -X GET "https://localhost:9164/management/task-status?name=SampleScheduledTask" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+	    ```
+    === "Response"          
+	    ```bash  
+	    {
+	        "observedAt": "2026-06-27T20:16:43.801Z",
+	        "taskName": "SampleScheduledTask",
+	        "duplicate": false,
+	        "coordinationDbAvailable": true,
+	        "runningOn": [
+	            "node"
+	        ]
+	    }
+	    ```
+
+-	**Resource**: `/task-status?view=duplicates`
+
+	**Description**: Live duplicate check — lists the coordinated tasks currently running on two or more nodes. `"healthy": true` means no task is duplicated right now.
+
+	**Example**:
+
+    === "Request"
+	    ```bash  
+	    curl -X GET "https://localhost:9164/management/task-status?view=duplicates" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+	    ```
+    === "Response"          
+	    ```bash  
+	    {
+	        "duplicates": [
+	            {
+	                "nodes": [
+	                    "node",
+	                    "node1"
+	                ],
+	                "taskName": "SampleScheduledTask"
+	            }
+	        ],
+	        "healthy": false,
+	        "coordinationDbAvailable": true
+	    }
+	    ```
+
+-	**Resource**: `/task-status?view=history`
+
+	**Description**: Forensic duplication history — every recorded duplication episode, including short-lived ones. The `severity` is `OPEN` (still happening), `TRANSIENT` (recovered quickly), or `SUSTAINED` (persisted beyond roughly twice the heartbeat-retry interval). Add `&name={taskName}` to filter to one task.
+
+	**Example**:
+
+    === "Request"
+	    ```bash  
+	    curl -X GET "https://localhost:9164/management/task-status?view=history" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+	    ```
+    === "Response"          
+	    ```bash  
+	    {
+	        "coordinationDbAvailable": true,
+	        "episodes": [
+	            {
+	                "severity": "SUSTAINED",
+	                "nodes": "node,node1",
+	                "kind": "UNEXPECTED",
+	                "clearedAt": "2026-06-27T20:25:17.211Z",
+	                "taskName": "SampleScheduledTask",
+	                "detectedAt": "2026-06-27T20:24:24.160Z",
+	                "durationMs": 53051,
+	                "open": false,
+	                "destinedNode": "node"
+	            }
+	        ]
+	    }
+	    ```
+
+-	**Resource**: `/task-status?scope=local`
+
+	**Description**: The queried node's own in-memory set of running coordinated tasks. This view reads no database, so it keeps answering during a coordination database outage — query each node separately and compare.
+
+	**Example**:
+
+    === "Request"
+	    ```bash  
+	    curl -X GET "https://localhost:9164/management/task-status?scope=local" -H "accept: application/json" -H "Authorization: Bearer TOKEN" -k
+	    ```
+    === "Response"          
+	    ```bash  
+	    {
+	        "coordinationEnabled": true,
+	        "scope": "local",
+	        "source": "in-memory",
+	        "nodeId": "node",
+	        "tasks": [
+	            "SampleScheduledTask",
+	            "MSMP_sampleMessageProcessor_0"
+	        ]
+	    }
+	    ```
+
+	??? note "Coordination database outage"
+		If the coordination database is unavailable, the database-backed views degrade explicitly with `"coordinationDbAvailable": false` and a message — they never return a false `"healthy": true`. The `?scope=local` view is unaffected and keeps answering in this state.
+
 ### GET MESSAGE STORES
 
 -	**Resource**: `/message-stores`

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
               - Enable SSL Tunneling through Proxy Server: install-and-setup/setup/enabling-ssl-tunneling-thru-proxy-server.md
           - Time Stamp Conversion for RDBMS: install-and-setup/setup/feature-configs/configuring-timestamp-conversion-for-rdbms.md
           - Coordinated Task Delete Barrier: install-and-setup/setup/feature-configs/configuring-task-delete-barrier.md
+          - Coordinated Task Monitoring: install-and-setup/setup/feature-configs/configuring-task-monitoring.md
           - RDBMS Coordination Configuration: install-and-setup/setup/feature-configs/configuring-rdbms-coordination.md
       - Deploy:
           - "Deploy the WSO2 Integrator: MI":


### PR DESCRIPTION


## Purpose
Documents the new coordinated task monitoring feature:
- New feature page under Setup > Feature Configurations covering the monitoring tables, the [task_handling] enable_task_monitoring toggle, the task-status Management API views, and log-based alerting
- GET TASK STATUS resource reference in the Management API page
- Navigation entry in mkdocs.yml