### PR TITLE
Fix Integration Studio download link to point to correct page (4.3.0)

### DIFF
--- a/en/docs/develop/installing-wso2-integration-studio.md
+++ b/en/docs/develop/installing-wso2-integration-studio.md
@@ -23,7 +23,7 @@ WSO2 Integration Studio provides a comprehensive development experience for buil
 
 Follow the steps given below.
 
-1.  Go to the [API Manager Tooling web page](https://wso2.com/api-management/tooling/), and download WSO2 Integration Studio.
+1.  Go to the [WSO2 Integration Studio page](https://wso2.com/micro-integrator/integration-studio/), and download WSO2 Integration Studio.
 
     !!! Note
         * If you are a MacOS user, be sure to add it to the **Applications** directory.


### PR DESCRIPTION
## Purpose
Resolves #1497 (4.3.0)

## Goals
Fix the broken Integration Studio download link that currently points to the API Manager Tooling page instead of the WSO2 Integration Studio page.

## Approach
Updated the download link from `https://wso2.com/api-management/tooling/` to `https://wso2.com/micro-integrator/integration-studio/`, which is the correct page for downloading WSO2 Integration Studio.

## User stories
As a developer setting up WSO2 Integration Studio for the first time, I want the download link in the installation guide to take me directly to the correct download page.

## Release note
Fixed the WSO2 Integration Studio download link in the installation documentation.

## Documentation
`en/docs/develop/installing-wso2-integration-studio.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Verified the corrected link resolves to the correct WSO2 Integration Studio download page.

## Learning
N/A