### PR TITLE
Distinguish ICP 1.2.0 and 2.0.0 instructions

### DIFF
--- a/en/docs/install-and-setup/install/running-the-integration-control-plane.md
+++ b/en/docs/install-and-setup/install/running-the-integration-control-plane.md
@@ -20,34 +20,50 @@ database, listen on `https://localhost:9446`, and create an `admin` user.
 
 ### Database settings
 
-By default ICP uses an embedded H2 database stored in `bin/database/`. For
-production, switch to PostgreSQL, MySQL, or MSSQL by uncommenting and editing
-the `[icp_server.storage]` section in `deployment.toml`:
+=== "ICP 2.0.0"
 
-```toml
-[icp_server.storage]
-dbType   = "postgresql"
-dbHost   = "db.example.com"
-dbPort   = 5432
-dbName   = "icp_database"
-dbUser   = "icp_user"
-dbPassword = "changeme"
-```
+    By default ICP uses an embedded H2 database stored in `bin/database/`. For
+    production, switch to PostgreSQL, MySQL, or MSSQL by uncommenting and editing
+    the `[icp_server.storage]` section in `deployment.toml`:
 
-A separate credentials database stores user passwords. Configure it with the
-`credentialsDb*` settings if you want credential storage on the same external
-database:
+    ```toml
+    [icp_server.storage]
+    dbType   = "postgresql"
+    dbHost   = "db.example.com"
+    dbPort   = 5432
+    dbName   = "icp_database"
+    dbUser   = "icp_user"
+    dbPassword = "changeme"
+    ```
 
-```toml
-credentialsDbType     = "postgresql"
-credentialsDbHost     = "db.example.com"
-credentialsDbPort     = 5432
-credentialsDbName     = "credentialsdb"
-credentialsDbUser     = "icp_user"
-credentialsDbPassword = "changeme"
-```
+    A separate credentials database stores user passwords. Configure it with the
+    `credentialsDb*` settings if you want credential storage on the same external
+    database:
 
-When using H2 (the default), no database configuration is needed.
+    ```toml
+    credentialsDbType     = "postgresql"
+    credentialsDbHost     = "db.example.com"
+    credentialsDbPort     = 5432
+    credentialsDbName     = "credentialsdb"
+    credentialsDbUser     = "icp_user"
+    credentialsDbPassword = "changeme"
+    ```
+
+    When using H2 (the default), no database configuration is needed.
+
+=== "ICP 1.2.0"
+
+    ICP 1.2.0 does not ship an embedded application database, and has no
+    `[icp_server.storage]` or `credentialsDb*` settings — those are specific to
+    2.0.0's rewritten backend. By default, ICP 1.2.0 authenticates users from a
+    flat file baked into `conf/user-mgt.xml`, with no database involved.
+
+    To back user management with an external RDBMS instead, switch to the JDBC
+    user store in `conf/user-mgt.xml` and initialize the schema using the script
+    for your database under `dbscripts/` (for example, `dbscripts/mysql/mysql_user.sql`
+    or `dbscripts/postgres/postgresql_user.sql`). See
+    [Built-in User Store]({{base_path}}/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp)
+    for the full ICP 1.2.0 walkthrough.
 
 ### Observability Settings (OpenSearch)
 

--- a/en/docs/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp.md
+++ b/en/docs/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp.md
@@ -4,6 +4,18 @@ The built-in user store keeps user credentials — password hashes, salts, and p
 
 By default both databases use the embedded H2 engine, writing to `<ICP_HOME>/bin/database/`. For production, switch the credentials database to PostgreSQL, MySQL, or MSSQL.
 
+!!! note "ICP 1.2.0"
+    ICP 1.2.0 has no separate credentials database — this page describes the
+    ICP 2.0.0 built-in user store. By default, ICP 1.2.0 authenticates users
+    from a flat file baked into `conf/user-mgt.xml` (the `admin` / `admin`
+    account seeded there), with no database involved.
+
+    To back user management with an external RDBMS instead, switch
+    `conf/user-mgt.xml` to the JDBC user store
+    (`org.wso2.dashboard.security.user.core.jdbc.JDBCUserStoreManager`) and
+    initialize the schema using the script for your database under
+    `dbscripts/` — for example `dbscripts/mysql/mysql_user.sql` or
+    `dbscripts/postgres/postgresql_user.sql`.
 
 ## Default Setup (H2)
 


### PR DESCRIPTION
## Purpose

MI 4.6.0 ICP documentation ([running-the-integration-control-plane](https://mi.docs.wso2.com/en/latest/install-and-setup/install/running-the-integration-control-plane/) and [use-built-in-userstore-in-icp](https://mi.docs.wso2.com/en/latest/install-and-setup/setup/user-stores/use-built-in-userstore-in-icp/)) was written against ICP 2.0.0 only. MI 4.6.0 is also compatible with ICP 1.2.0, whose configuration differs enough (no embedded database, file-based user store by default) that following the 2.0.0 steps doesn't work for it.

Resolves #2345

This supersedes #2347, which was closed because the ICP 1.2.0 specifics in that version (`conf/Config.toml`, a `db-scripts/` path mirroring 2.0.0) were guessed and incorrect, per @chanikag's review. This PR replaces those guesses with facts verified against the actual product.

## Goals

- Correctly distinguish which instructions apply to ICP 1.2.0 vs 2.0.0 on the two pages referenced in #2345.
- Base every version-specific claim on the real product instead of inference.

## Approach

Verified directly against the `wso2/wso2-integration-control-plane` `1.2.0` and `2.0.0` Docker images — inspected both image filesystems and booted 1.2.0 to confirm runtime behavior:

- Both versions use `conf/deployment.toml` — not different file names as previously assumed.
- ICP 1.2.0 has no `[icp_server.storage]` or `credentialsDb*` keys and ships no embedded application database. By default it authenticates from a flat file in `conf/user-mgt.xml` (confirmed: no `.db` file is created even after a real startup).
- An RDBMS-backed user store on 1.2.0 goes through `user-mgt.xml`'s JDBC user store (`org.wso2.dashboard.security.user.core.jdbc.JDBCUserStoreManager`), initialized from the per-vendor scripts under `dbscripts/` (e.g. `dbscripts/mysql/mysql_user.sql`), rather than through `deployment.toml` keys.

Where ICP 1.2.0 genuinely has no equivalent to a 2.0.0 feature (e.g. the separate credentials database), the docs now say so explicitly instead of inventing a parallel path for it.

## User stories

As an operator setting up MI 4.6.0 with ICP 1.2.0, I want accurate instructions for the default file-based user store and for switching to an RDBMS-backed one, instead of instructions written for ICP 2.0.0's architecture.

## Release note
N/A

## Documentation
N/A (This is a documentation-only fix).

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A (Documentation changes).

## Security checks
Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
Ran FindSecurityBugs plugin and verified report? N/A
Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Supersedes #2347 (closed - technical content was incorrect)

## Migrations (if applicable)
N/A