### PR TITLE
Update jdbc tuning doc with network timeout configurations

### DIFF
--- a/en/docs/install-and-setup/setup/performance-tuning/jdbc-tuning.md
+++ b/en/docs/install-and-setup/setup/performance-tuning/jdbc-tuning.md
@@ -124,3 +124,52 @@ The following properties are used for detecting and removing the connections tha
 !!! Info
     -   When it comes to web applications, users are free to experiment and package their own pooling framework such BoneCP.
     -   If you are using an Oracle database, you may sometimes come across an error (ORA-04031) indicating that you have not allocated enough memory for the shared pool of connections. To overcome this, you can allocate more memory to the shared pool by adjusting the following parameters in the <ORACLE_HOME>/dbs/init<SID>.ora file of your Oracle database: SHARED_POOL_RESERVED_SIZE, SHARED_POOL_SIZE and LARGE_POOL_SIZE.
+
+## Configuring JDBC connection-establishment timeouts
+
+The pool properties above bound how long a request waits for a connection from the pool, but not the time taken to establish the initial connection to the database. If the target database is unreachable at the network level, the server can hang while connecting to it, without logging an error.
+
+!!! Warning
+    The parameters below are JDBC driver/database vendor-specific settings, not Micro Integrator `pool_options.*` properties. Set them via the datasource `url`, or via `pool_options.connectionProperties`, which is forwarded as-is to the JDBC driver.
+
+### Oracle
+
+```toml
+[[datasource]]
+id = "sample_datasource"
+url = "jdbc:oracle:thin:@(DESCRIPTION=(CONNECT_TIMEOUT=10)(RETRY_COUNT=0)(ADDRESS_LIST=(ADDRESS=(HOST=<host>)(PORT=<port>)(PROTOCOL=TCP)))(CONNECT_DATA=(SERVICE_NAME=<service>)))"
+```
+
+To also bound query execution once connected, add `oracle.jdbc.ReadTimeout` (milliseconds):
+
+```toml
+pool_options.connectionProperties = "oracle.jdbc.ReadTimeout=10000"
+```
+
+### Microsoft SQL Server
+
+```toml
+[[datasource]]
+id = "sample_datasource"
+url = "jdbc:sqlserver://<host>:1433;databaseName=<db>;loginTimeout=10;socketTimeout=10000"
+```
+
+Or via `connectionProperties`:
+
+```toml
+pool_options.connectionProperties = "loginTimeout=10;socketTimeout=10000"
+```
+
+### MySQL
+
+```toml
+[[datasource]]
+id = "sample_datasource"
+url = "jdbc:mysql://<host>:3306/<db>?connectTimeout=10000&socketTimeout=10000"
+```
+
+Or via `connectionProperties`:
+
+```toml
+pool_options.connectionProperties = "connectTimeout=10000;socketTimeout=10000"
+```


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

The current JDBC tuning document  only documents *pool-sizing* parameters (`maxActive`, `maxWait`, `minIdle`, `testOnBorrow`, `validationInterval`, `validationQuery`, `removeAbandoned*`). It has no guidance on **connection-establishment timeouts** , the parameters that bound the initial TCP connect + driver handshake phase, before a connection ever enters the pool.

This gap has a concrete, reproducible failure mode: if a datasource used by a CAR-packaged data service points at a DB host that accepts the TCP connection but never completes the driver's protocol handshake (DB down mid-negotiation, firewall silently accepting SYN then dropping, network black hole, etc.), the Micro Integrator startup thread blocks **indefinitely** . No exception is thrown, no log line is written, and `maxWait` does **not** help , it only bounds the wait for an *already-initialized* pool connection, not the physical connect. The only way out is killing the process and removing the offending CAR file.


<img width="1495" height="870" alt="Screenshot 2026-08-17 at 07 30 31" src="https://github.com/user-attachments/assets/b56dd2c9-535c-48bf-9e7b-a60a7e74455b" />
