### PR TITLE
Update File Connector zip operation docs (unzip/exploreZipFile)

### DIFF
--- a/en/docs/reference/connectors/file-connector/4.x/file-connector-config.md
+++ b/en/docs/reference/connectors/file-connector/4.x/file-connector-config.md
@@ -2889,6 +2889,26 @@ The following operations allow you to work with the File Connector version 4. Cl
                 No
             </td>
         </tr>
+        <tr>
+            <td>
+                Include File Names
+            </td>
+            <td>
+                includeFileNames
+            </td>
+            <td>
+                Boolean
+            </td>
+            <td>
+                 If set to true, the names of the extracted files are returned in the response under <code>zipFileContent</code>. Available from File Connector <b>v4.0.45</b> and above.
+            </td>
+            <td>
+                false
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
     </table>
 
     > NOTE: The latest File connector (v4.0.7 onwards) supports decompressing the .gz files.
@@ -2913,19 +2933,25 @@ The following operations allow you to work with the File Connector version 4. Cl
 
     **Response** 
 
+    By default (when `includeFileNames` is not set or is `false`):
+
     ```xml
     <unzipFileResult>
-       <success>true</success>
-       <zipFileContent>
-           <test1.txt>extracted</test1.txt>
-           <test2.txt>extracted</test2.txt>
-           <hasitha--a1.txt>extracted</hasitha--a1.txt>
-           <hasitha--a2.txt>extracted</hasitha--a2.txt>
-           <hasitha--b--b2.txt>extracted</hasitha--b--b2.txt>
-           <hasitha--b--b1.txt>extracted</hasitha--b--b1.txt>
-           <hasitha--b--c--test1.txt>extracted</hasitha--b--c--test1.txt>
-           <hasitha--b--c--c1.txt>extracted</hasitha--b--c--c1.txt>
-       </zipFileContent>
+        <success>true</success>
+    </unzipFileResult>
+    ```
+
+    When `includeFileNames` is set to `true`:
+
+    ```xml
+    <unzipFileResult>
+        <success>true</success>
+        <zipFileContent>
+            <file>test1.txt</file>
+            <file>test2.txt</file>
+            <file>docs/a1.txt</file>
+            <file>docs/archive/c1.txt</file>
+        </zipFileContent>
     </unzipFileResult>
     ```
 
@@ -3492,8 +3518,28 @@ The following operations allow you to work with the File Connector version 4. Cl
                 Yes
             </td>
         </tr>
+        <tr>
+            <td>
+                File Name Encoding
+            </td>
+            <td>
+                fileNameEncoding
+            </td>
+            <td>
+                String
+            </td>
+            <td>
+                 The character encoding to interpret the file names inside the ZIP archive. Available from File Connector <b>v4.0.45</b> and above.
+            </td>
+            <td>
+                UTF-8
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
     </table>
-    
+
     **Sample configuration**
     ```xml
     <file.exploreZipFile configKey="CONNECTION_NAME">
@@ -3514,17 +3560,13 @@ The following operations allow you to work with the File Connector version 4. Cl
 
     ```xml
     <exploreZipFileResult>
-       <success>true</success>
-       <zipFileContent>
-           <file>test1.txt</file>
-           <file>test2.txt</file>
-           <file>hasitha/a1.txt</file>
-           <file>hasitha/a2.txt</file>
-           <file>hasitha/b/b2.txt</file>
-           <file>hasitha/b/b1.txt</file>
-           <file>hasitha/b/c/test1.txt</file>
-           <file>hasitha/b/c/c1.txt</file>
-       </zipFileContent>
+        <success>true</success>
+        <zipFileContent>
+            <file>test1.txt</file>
+            <file>test2.txt</file>
+            <file>docs/a1.txt</file>
+            <file>docs/archive/c1.txt</file>
+        </zipFileContent>
     </exploreZipFileResult>
     ```
 

--- a/en/docs/reference/connectors/file-connector/5.x/file-connector-config.md
+++ b/en/docs/reference/connectors/file-connector/5.x/file-connector-config.md
@@ -3221,6 +3221,26 @@ The following operations allow you to work with the File Connector. Click an ope
                 No
             </td>
         </tr>
+        <tr>
+            <td>
+                Include File Names
+            </td>
+            <td>
+                includeFileNames
+            </td>
+            <td>
+                Boolean
+            </td>
+            <td>
+                 If set to true, the names of the extracted files are returned in the response under <code>zipFileContent</code>. Available from File Connector <b>v5.0.5</b> and above.
+            </td>
+            <td>
+                false
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
     </table>
 
     > NOTE: The latest File connector (v4.0.7 onwards) supports decompressing the .gz files.
@@ -3247,9 +3267,25 @@ The following operations allow you to work with the File Connector. Click an ope
 
     **Response** 
 
+    By default (when `includeFileNames` is not set or is `false`):
+
     ```json
     {
         "success": true
+    }
+    ```
+
+    When `includeFileNames` is set to `true`:
+
+    ```json
+    {
+        "success": true,
+        "zipFileContent": [
+            "test1.txt",
+            "test2.txt",
+            "docs/a1.txt",
+            "docs/archive/c1.txt"
+        ]
     }
     ```
 
@@ -3938,6 +3974,26 @@ The following operations allow you to work with the File Connector. Click an ope
                 Yes
             </td>
         </tr>
+        <tr>
+            <td>
+                File Name Encoding
+            </td>
+            <td>
+                fileNameEncoding
+            </td>
+            <td>
+                String
+            </td>
+            <td>
+                 The character encoding to interpret the file names inside the ZIP archive. Available from File Connector <b>v5.0.5</b> and above.
+            </td>
+            <td>
+                UTF-8
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
     </table>
     
     **Sample configuration**
@@ -3962,18 +4018,14 @@ The following operations allow you to work with the File Connector. Click an ope
 
     ```json
     {
-           "success": true,
-           "zipFileContent": [
-               "test1.txt",
-               "test2.txt",
-               "hasitha/a1.txt",
-               "hasitha/a2.txt",
-               "hasitha/b/b2.txt",
-               "hasitha/b/b1.txt",
-               "hasitha/b/c/test1.txt",
-               "hasitha/b/c/c1.txt"
-           ]
-       }
+        "success": true,
+        "zipFileContent": [
+            "test1.txt",
+            "test2.txt",
+            "docs/a1.txt",
+            "docs/archive/c1.txt"
+        ]
+    }
     ```
 
     **On Error** 

--- a/en/docs/reference/connectors/file-connector/6.x/file-connector-config.md
+++ b/en/docs/reference/connectors/file-connector/6.x/file-connector-config.md
@@ -3470,6 +3470,26 @@ The following operations allow you to work with the File Connector. Click an ope
         </tr>
         <tr>
             <td>
+                Include File Names
+            </td>
+            <td>
+                includeFileNames
+            </td>
+            <td>
+                Boolean
+            </td>
+            <td>
+                 If set to true, the names of the extracted files are returned in the response under <code>zipFileContent</code>. Available from File Connector <b>v6.0.6</b> and above.
+            </td>
+            <td>
+                false
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
+        <tr>
+            <td>
                 Time Between Size Check
             </td>
             <td>
@@ -3516,9 +3536,25 @@ The following operations allow you to work with the File Connector. Click an ope
 
     **Response** 
 
+    By default (when `includeFileNames` is not set or is `false`):
+
     ```json
     {
         "success": true
+    }
+    ```
+
+    When `includeFileNames` is set to `true`:
+
+    ```json
+    {
+        "success": true,
+        "zipFileContent": [
+            "test1.txt",
+            "test2.txt",
+            "docs/a1.txt",
+            "docs/archive/c1.txt"
+        ]
     }
     ```
 
@@ -4418,6 +4454,26 @@ The following operations allow you to work with the File Connector. Click an ope
                 Yes
             </td>
         </tr>
+        <tr>
+            <td>
+                File Name Encoding
+            </td>
+            <td>
+                fileNameEncoding
+            </td>
+            <td>
+                String
+            </td>
+            <td>
+                 The character encoding to interpret the file names inside the ZIP archive. Available from File Connector <b>v6.0.6</b> and above.
+            </td>
+            <td>
+                UTF-8
+            </td>
+            <td>
+                No
+            </td>
+        </tr>
     </table>
     
     **Sample configuration**
@@ -4442,18 +4498,14 @@ The following operations allow you to work with the File Connector. Click an ope
 
     ```json
     {
-           "success": true,
-           "zipFileContent": [
-               "test1.txt",
-               "test2.txt",
-               "hasitha/a1.txt",
-               "hasitha/a2.txt",
-               "hasitha/b/b2.txt",
-               "hasitha/b/b1.txt",
-               "hasitha/b/c/test1.txt",
-               "hasitha/b/c/c1.txt"
-           ]
-       }
+        "success": true,
+        "zipFileContent": [
+            "test1.txt",
+            "test2.txt",
+            "docs/a1.txt",
+            "docs/archive/c1.txt"
+        ]
+    }
     ```
 
     **On Error** 


### PR DESCRIPTION
## Summary
- Removes the `unzip` response example showing the legacy File Connector v2 format.
- Documents the new `fileNameEncoding` parameter on `exploreZipFile` and the new `includeFileNames` parameter on `unzip`.

Related: wso2/product-integrator-mi#5014
