### PR TITLE
Add binaryAttributes parameter to LDAP connector configuration

### DIFF
--- a/en/docs/reference/connectors/ldap-connector/1.x/ldap-server-1.x-configuration.md
+++ b/en/docs/reference/connectors/ldap-connector/1.x/ldap-server-1.x-configuration.md
@@ -35,6 +35,16 @@ To use the LDAP connector, add the `<ldap.init>` element in your configuration b
             <td>The boolean value to check whether the certificate is enabled or not.</td>
             <td>Yes</td>
         </tr>
+        <tr>
+            <td>binaryAttributes</td>
+            <td>
+                A list of space-separated attribute names that should be treated as binary attributes. The values of these attributes will be returned as base64-encoded strings.
+                <hr/>
+                **Note**: This configuration is available from LDAP connector version **1.0.17 and above**.
+                `objectGUID` is treated as a binary attribute by default and it will be returned as UUID string.
+            </td>
+            <td>No</td>
+        </tr>
     </table>
 
     **Sample configuration**

--- a/en/docs/reference/connectors/ldap-connector/ldap-server-configuration.md
+++ b/en/docs/reference/connectors/ldap-connector/ldap-server-configuration.md
@@ -66,6 +66,16 @@ The connection is used to establish a connection to the LDAP instance. The LDAP 
             <td>The maximum number of connections per connection identity that can be maintained concurrently.</td>
             <td>No</td>
         </tr>
+        <tr>
+            <td>binaryAttributes</td>
+            <td>
+                A list of space-separated attribute names that should be treated as binary attributes. The values of these attributes will be returned as base64-encoded strings.
+                <hr/>
+                **Note**: This configuration is available from LDAP connector version **2.0.3 and above**.
+                `objectGUID` is treated as a binary attribute by default and it will be returned as UUID string.
+            </td>
+            <td>No</td>
+        </tr>
     </table>
 
     **Sample configuration**


### PR DESCRIPTION
This pull request adds documentation for a new `binaryAttributes` configuration option in the LDAP connector documentation. This option allows users to specify which LDAP attributes should be treated as binary and returned as base64-encoded strings.

Documentation updates for LDAP connector:

* Added the `binaryAttributes` parameter to the configuration tables in both `ldap-server-1.x-configuration.md` and `ldap-server-configuration.md`, explaining its purpose and usage. 

Fix:  https://github.com/wso2/product-integrator-mi/issues/5023