### PR TITLE
Port network-related parameters tip to JDBC Message Store doc for main

### DIFF
--- a/en/docs/reference/synapse-properties/message-stores/jdbc-msg-store-properties.md
+++ b/en/docs/reference/synapse-properties/message-stores/jdbc-msg-store-properties.md
@@ -117,7 +117,7 @@ The syntax of the JDBC message store can be different depending on whether you c
 The syntax of the JDBC message store can be different depending on whether you connect to the database using a connection pool, or using a datasource. Given below are the external datasource properties:
 
 !!! Tip
-    Network-related parameters, such as connection and socket timeouts, may need to be fine-tuned based on your environment. For more information, see [Tuning JDBC Pool Configurations]({{base_path}}/install-and-setup/setup/performance-tuning/jdbc-tuning/).
+    Network-related parameters, such as connection and socket timeouts, may need to be fine-tuned based on your environment. For more information, see [Tuning JDBC Pool Configurations]({{base_path}}/install-and-setup/setup/performance-tuning/jdbc-tuning).
 
 <table>
   <tr>

--- a/en/docs/reference/synapse-properties/message-stores/jdbc-msg-store-properties.md
+++ b/en/docs/reference/synapse-properties/message-stores/jdbc-msg-store-properties.md
@@ -72,6 +72,9 @@ The following properties are required when [creating a JDBC Message Store]({{bas
 
 The syntax of the JDBC message store can be different depending on whether you connect to the database using a connection pool, or using a datasource. Given below are the connection pool properties:
 
+!!! Tip
+    You can specify JDBC driver- or database vendor-specific settings as query parameters in the `store.jdbc.connection.url`. This includes network-related settings, such as connection and socket timeouts, which may need to be fine-tuned based on your environment. For the supported parameters and recommended values, see the documentation for your JDBC driver or database vendor.
+
 <table>
   <tr>
     <th>Property</th>
@@ -112,6 +115,9 @@ The syntax of the JDBC message store can be different depending on whether you c
 ### External Datasource Properties
 
 The syntax of the JDBC message store can be different depending on whether you connect to the database using a connection pool, or using a datasource. Given below are the external datasource properties:
+
+!!! Tip
+    Network-related parameters, such as connection and socket timeouts, may need to be fine-tuned based on your environment. For more information, see [Tuning JDBC Pool Configurations]({{base_path}}/install-and-setup/setup/performance-tuning/jdbc-tuning/).
 
 <table>
   <tr>


### PR DESCRIPTION
## Purpose
Resolves #2414

## Goals
Port the network-related parameters tip from PR #2411 to the main branch.

## Approach
Added two tips to the JDBC Message Store documentation:
1. Connection pool properties section - noting that JDBC driver-specific settings including network-related settings can be specified as URL parameters in the connection URL.
2. External datasource properties section - referencing the "Tuning JDBC Pool Configurations" guide for network-related parameter tuning.

## User stories
As a WSO2 MI developer, I want guidance on tuning network-related parameters for the JDBC Message Store so that I can optimize my integration's performance.

## Release note
Documentation updated for JDBC Message Store to include tips on network-related parameter tuning.

## Documentation
`en/docs/reference/synapse-properties/message-stores/jdbc-msg-store-properties.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
#2411

## Migrations
N/A

## Test environment
Tested on Fedora OS (local documentation verification).

## Learning
N/A