### PR TITLE
Fix broken sample WSDL download link in proxy service introduction doc

### DIFF
--- a/en/docs/learn/examples/proxy-service-examples/introduction-to-proxy-services.md
+++ b/en/docs/learn/examples/proxy-service-examples/introduction-to-proxy-services.md
@@ -20,7 +20,7 @@ An `inSequence` or `endpoint` or both of these would decide how the message woul
             <respond/>
         </inSequence>
     </target>
-    <publishWSDL uri="file:/path/to/sample_proxy_1.wsdl"/>
+    <publishWSDL uri="file:/path/to/sample_proxy_3.wsdl"/>
 </proxy>
 ```
 
@@ -32,8 +32,8 @@ Create the artifacts:
 3. [Create the proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
 
     !!! Tip
-        Download the wsdl file ([sample_proxy_3.wsdl]({{base_path}}/assets/attachments/wsdl/sample_proxy_3.wsdl)).
-        The wsdl uri in the proxy service needs to be updated with the path to this `sample_proxy_3.wsdl` file.
+        Download the WSDL file [sample_proxy_3.wsdl]({{base_path}}/assets/attachments/wsdl/sample_proxy_3.wsdl).
+        The WSDL URI in the proxy service needs to be updated with the path to this `sample_proxy_3.wsdl` file.
 
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 

--- a/en/docs/learn/examples/proxy-service-examples/introduction-to-proxy-services.md
+++ b/en/docs/learn/examples/proxy-service-examples/introduction-to-proxy-services.md
@@ -32,8 +32,8 @@ Create the artifacts:
 3. [Create the proxy service]({{base_path}}/develop/creating-artifacts/creating-a-proxy-service) with the configurations given above.
 
     !!! Tip
-        Download the wsdl file (`sample_proxy_1.wsdl`) from [sample_proxy_1.wsdl](https://github.com/wso2-docs/WSO2_EI/blob/master/samples-protocol-switching/sample_proxy_1.wsdl).
-        The wsdl uri in the proxy service needs to be updated with the path to this `sample_proxy_1.wsdl` file.
+        Download the wsdl file ([sample_proxy_3.wsdl]({{base_path}}/assets/attachments/wsdl/sample_proxy_3.wsdl)).
+        The wsdl uri in the proxy service needs to be updated with the path to this `sample_proxy_3.wsdl` file.
 
 4. [Deploy the artifacts]({{base_path}}/develop/deploy-artifacts) in your WSO2 Integrator: MI.
 


### PR DESCRIPTION
## Purpose
Partially addresses #2438

## Goals
Fix the broken WSDL download link in the "How to Use a Simple Proxy Service" tutorial. The `wso2-docs/WSO2_EI` repository referenced in this link no longer exists (returns 404), so the link is completely dead.

## Approach
Replaced the dead link to `sample_proxy_1.wsdl` (hosted on the now-deleted `wso2-docs/WSO2_EI` repo) with a reference to `sample_proxy_3.wsdl`, an equivalent sample WSDL file already hosted internally at `{{base_path}}/assets/attachments/wsdl/sample_proxy_3.wsdl` and used successfully in other pages (e.g. the Messaging Gateway EIP doc).

## Note on scope
This issue also reports a second broken link, to a `Back-End-Service/axis2Server.zip` file hosted on the same deleted `wso2-docs/WSO2_EI` repository. That same broken link appears across many other documentation pages (JMS examples, protocol-switching examples, REST API examples, etc.), so fixing it requires hosting a replacement backend service archive somewhere accessible - this is an infrastructure decision that needs a WSO2 team member with appropriate repository/hosting permissions. This PR only fixes the WSDL link, which had a ready internal replacement.

## User stories
As a developer following the "How to Use a Simple Proxy Service" tutorial, I want the WSDL download link to work so that I can complete the tutorial without hitting a dead link.

## Release note
Fixed a broken sample WSDL download link in the proxy service introduction tutorial.

## Documentation
`en/docs/learn/examples/proxy-service-examples/introduction-to-proxy-services.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Verified `sample_proxy_3.wsdl` exists at `en/docs/assets/attachments/wsdl/sample_proxy_3.wsdl` and is already referenced successfully elsewhere in the docs.

## Learning
Investigated the reported broken links and found the source repository (`wso2-docs/WSO2_EI`) has been deleted entirely. Found an existing internally-hosted WSDL sample that serves the same purpose for the first broken link.