### PR TITLE
Add guidance on shared registry mounting for MI cluster on Kubernetes

### DIFF
--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -63,7 +63,7 @@ You can still deploy these stateful artifacts in multiple replicas as long as co
 
 !!! Tip
     - See [Coordination configurations]({{base_path}}/install-and-setup/setup/deployment/configuring-helm-charts/#coordination-configurations) for instructions on configuring coordination across multiple WSO2 Integrator: MI instances using the Helm charts.
-    - If you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, you must share the registry across WSO2 Integrator: MI instances to persist the state when new nodes join the cluster. Refer to the [Registry synchronization](#registry-synchronization) section below for Kubernetes-specific instructions. Registry synchronization is an optional setup and is not required for basic coordination.
+    - If you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, you must share the registry across WSO2 Integrator: MI instances to persist the state when new nodes join the cluster. Refer to the [Registry synchronization](#registry-synchronization) for Kubernetes-specific instructions. Registry synchronization is an optional setup and is not required for basic coordination.
 
 <img src="{{base_path}}/assets/img/integrate/k8s_deployment/k8s_coordination.png">
 
@@ -80,14 +80,11 @@ If the MI instance currently executing a particular artifact becomes unavailable
 
 ### Registry synchronization
 
-!!! Note
-    Registry sharing is required only if your deployment includes Message Processors or Inbound Endpoints and you need runtime state changes (**active**/**inactive**)—for example, toggled via the Management API or Integration Control Plane—to persist when new nodes join the cluster. If you do not use runtime state changes, registry sharing is not required for basic coordination.
-
-The shared registry maintains the state (**active**/**inactive**) of the Message Processor or Inbound Endpoint artifact, ensuring that the same state is maintained across all WSO2 Integrator: MI replicas in the cluster.
+Registry sharing is required if your deployment includes Message Processors, Inbound Endpoints, or any other artifact state or data that needs to be consistent across all nodes in the cluster. 
 
 In a Kubernetes deployment, since pods are ephemeral and do not share a local file system by default, the `<MI_HOME>/registry` directory must be backed by a shared, persistent volume that is accessible by all replicas simultaneously.
 
-1.  Ensure your Kubernetes environment has a `StorageClass` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount the same volume concurrently. Common examples include NFS-backed storage, Azure Files, or a cloud provider's shared file storage service. If no RWX-capable `StorageClass` is available, a `PersistentVolume` can instead be provisioned and bound manually.
+1.  Ensure your Kubernetes environment has a `StorageClass` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount the same volume concurrently. Follow your Kubernetes provider's documentation to provision RWX-capable storage in your environment.
 2.  Create a `PersistentVolumeClaim` (PVC) that requests this shared volume.
 
     ```yaml
@@ -122,6 +119,3 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
               persistentVolumeClaim:
                 claimName: mi-shared-registry-pvc
     ```
-
-!!! Tip
-    If your Kubernetes cluster or cloud provider does not support `ReadWriteMany` volumes, consider using an external file storage solution (such as NFS) provisioned outside the cluster and mounted into each pod, or evaluate whether registry sharing is actually required for your use case before introducing this additional infrastructure dependency.

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -77,3 +77,29 @@ You can still deploy these stateful artifacts in multiple replicas as long as co
 When stateful artifacts are deployed with coordination enabled across multiple WSO2 Integrator: MI replicas, each artifact such as Scheduled triggers or message processors is executed by only one MI instance at a time. By default, these artifacts are automatically assigned to available nodes in the cluster, ensuring consistent and conflict free execution.
 
 If the MI instance currently executing a particular artifact becomes unavailable, another node will seamlessly take over its execution. This ensures high availability and avoids service interruptions by enabling automatic failover of stateful tasks.
+
+### Registry synchronization
+
+!!! Note
+    Registry sharing is only required if you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, and you want that state to persist when new nodes join the cluster. If you do not use these dynamic state changes, registry sharing is not required for basic coordination.
+
+The shared registry maintains the state (**active**/**inactive**) of the Message Processor/inbound endpoint artifact, ensuring that the same state is maintained across all WSO2 Integrator: MI replicas in the cluster.
+
+In a Kubernetes deployment, since pods are ephemeral and do not share a local file system by default, the `<MI_HOME>/registry` directory must be backed by a shared, persistent volume that is accessible by all replicas simultaneously.
+
+1.  Provision a `PersistentVolume` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount it concurrently. The exact storage class depends on your Kubernetes environment (for example, NFS-backed storage, Azure Files, or a cloud provider's file storage service).
+2.  Create a `PersistentVolumeClaim` (PVC) that requests this shared volume.
+3.  Mount the PVC at the `<MI_HOME>/registry` path in the WSO2 Integrator: MI container specification, using the same PVC across all replicas in the Deployment or StatefulSet.
+
+```yaml
+    volumeMounts:
+      - name: shared-registry
+        mountPath: <MI_HOME>/registry
+    volumes:
+      - name: shared-registry
+        persistentVolumeClaim:
+          claimName: mi-shared-registry-pvc
+```
+
+!!! Tip
+    If your Kubernetes cluster or cloud provider does not support `ReadWriteMany` volumes, consider using an external file storage solution (such as NFS) provisioned outside the cluster and mounted into each pod, or evaluate whether registry sharing is actually required for your use case before introducing this additional infrastructure dependency.

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -116,7 +116,7 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
             - name: mi
               volumeMounts:
                 - name: shared-registry
-                  mountPath: /home/wso2carbon/wso2mi-4.1.0/registry
+                  mountPath: "<MI_HOME>/registry"
           volumes:
             - name: shared-registry
               persistentVolumeClaim:

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -81,7 +81,7 @@ If the MI instance currently executing a particular artifact becomes unavailable
 ### Registry synchronization
 
 !!! Note
-    Registry sharing is only required if you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, and you want that state to persist when new nodes join the cluster. If you do not use these dynamic state changes, registry sharing is not required for basic coordination.
+    Registry sharing is required only if your deployment includes Message Processors or Inbound Endpoints and you need runtime state changes (**active**/**inactive**)—for example, toggled via the Management API or Integration Control Plane—to persist when new nodes join the cluster. If you do not use runtime state changes, registry sharing is not required for basic coordination.
 
 The shared registry maintains the state (**active**/**inactive**) of the Message Processor or Inbound Endpoint artifact, ensuring that the same state is maintained across all WSO2 Integrator: MI replicas in the cluster.
 
@@ -89,20 +89,36 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
 
 1.  Provision a `PersistentVolume` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount it concurrently. The exact storage class depends on your Kubernetes environment (for example, NFS-backed storage, Azure Files, or a cloud provider's file storage service).
 2.  Create a `PersistentVolumeClaim` (PVC) that requests this shared volume.
+
+    ```yaml
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mi-shared-registry-pvc
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: 1Gi
+    ```
+
 3.  Mount the PVC at the `<MI_HOME>/registry` path in the WSO2 Integrator: MI container specification, using the same PVC across all replicas in the Deployment or StatefulSet.
 
-```yaml
+    ```yaml
     spec:
-      containers:
-        - name: mi
-          volumeMounts:
+      template:
+        spec:
+          containers:
+            - name: mi
+              volumeMounts:
+                - name: shared-registry
+                  mountPath: "<MI_HOME>/registry"
+          volumes:
             - name: shared-registry
-              mountPath: <MI_HOME>/registry
-      volumes:
-        - name: shared-registry
-          persistentVolumeClaim:
-            claimName: mi-shared-registry-pvc
-```
+              persistentVolumeClaim:
+                claimName: mi-shared-registry-pvc
+    ```
 
 !!! Tip
     If your Kubernetes cluster or cloud provider does not support `ReadWriteMany` volumes, consider using an external file storage solution (such as NFS) provisioned outside the cluster and mounted into each pod, or evaluate whether registry sharing is actually required for your use case before introducing this additional infrastructure dependency.

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -113,7 +113,7 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
             - name: mi
               volumeMounts:
                 - name: shared-registry
-                  mountPath: "<MI_HOME>/registry"
+                  mountPath: /home/wso2carbon/wso2mi-4.1.0/registry
           volumes:
             - name: shared-registry
               persistentVolumeClaim:

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -98,10 +98,13 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
     spec:
       accessModes:
         - ReadWriteMany
+      storageClassName: "<RWX_STORAGE_CLASS_NAME>"
       resources:
         requests:
           storage: 1Gi
     ```
+
+    Replace `<RWX_STORAGE_CLASS_NAME>` with a StorageClass in your Kubernetes environment that supports `ReadWriteMany` access.
 
 3.  Mount the PVC at the `<MI_HOME>/registry` path in the WSO2 Integrator: MI container specification, using the same PVC across all replicas in the Deployment or StatefulSet.
 

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -63,7 +63,7 @@ You can still deploy these stateful artifacts in multiple replicas as long as co
 
 !!! Tip
     - See [Coordination configurations]({{base_path}}/install-and-setup/setup/deployment/configuring-helm-charts/#coordination-configurations) for instructions on configuring coordination across multiple WSO2 Integrator: MI instances using the Helm charts.
-    - If you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, you must share the registry across WSO2 Integrator: MI instances to persist the state when new nodes join the cluster. Refer to [Registry synchronization]({{base_path}}/install-and-setup/setup/deployment/deploying-wso2-mi/#registry-synchronization-sharing) for more information. Registry synchronization is an optional setup and is not required for basic coordination.
+    - If you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, you must share the registry across WSO2 Integrator: MI instances to persist the state when new nodes join the cluster. Refer to the [Registry synchronization](#registry-synchronization) section below for Kubernetes-specific instructions. Registry synchronization is an optional setup and is not required for basic coordination.
 
 <img src="{{base_path}}/assets/img/integrate/k8s_deployment/k8s_coordination.png">
 
@@ -83,7 +83,7 @@ If the MI instance currently executing a particular artifact becomes unavailable
 !!! Note
     Registry sharing is only required if you dynamically change the state of a Message Processor or Inbound Endpoint using the Management API or Integration Control Plane, and you want that state to persist when new nodes join the cluster. If you do not use these dynamic state changes, registry sharing is not required for basic coordination.
 
-The shared registry maintains the state (**active**/**inactive**) of the Message Processor/inbound endpoint artifact, ensuring that the same state is maintained across all WSO2 Integrator: MI replicas in the cluster.
+The shared registry maintains the state (**active**/**inactive**) of the Message Processor or Inbound Endpoint artifact, ensuring that the same state is maintained across all WSO2 Integrator: MI replicas in the cluster.
 
 In a Kubernetes deployment, since pods are ephemeral and do not share a local file system by default, the `<MI_HOME>/registry` directory must be backed by a shared, persistent volume that is accessible by all replicas simultaneously.
 
@@ -92,13 +92,16 @@ In a Kubernetes deployment, since pods are ephemeral and do not share a local fi
 3.  Mount the PVC at the `<MI_HOME>/registry` path in the WSO2 Integrator: MI container specification, using the same PVC across all replicas in the Deployment or StatefulSet.
 
 ```yaml
-    volumeMounts:
-      - name: shared-registry
-        mountPath: <MI_HOME>/registry
-    volumes:
-      - name: shared-registry
-        persistentVolumeClaim:
-          claimName: mi-shared-registry-pvc
+    spec:
+      containers:
+        - name: mi
+          volumeMounts:
+            - name: shared-registry
+              mountPath: <MI_HOME>/registry
+      volumes:
+        - name: shared-registry
+          persistentVolumeClaim:
+            claimName: mi-shared-registry-pvc
 ```
 
 !!! Tip

--- a/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
+++ b/en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md
@@ -87,7 +87,7 @@ The shared registry maintains the state (**active**/**inactive**) of the Message
 
 In a Kubernetes deployment, since pods are ephemeral and do not share a local file system by default, the `<MI_HOME>/registry` directory must be backed by a shared, persistent volume that is accessible by all replicas simultaneously.
 
-1.  Provision a `PersistentVolume` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount it concurrently. The exact storage class depends on your Kubernetes environment (for example, NFS-backed storage, Azure Files, or a cloud provider's file storage service).
+1.  Ensure your Kubernetes environment has a `StorageClass` that supports the `ReadWriteMany` (RWX) access mode, so that multiple pods can mount the same volume concurrently. Common examples include NFS-backed storage, Azure Files, or a cloud provider's shared file storage service. If no RWX-capable `StorageClass` is available, a `PersistentVolume` can instead be provisioned and bound manually.
 2.  Create a `PersistentVolumeClaim` (PVC) that requests this shared volume.
 
     ```yaml


### PR DESCRIPTION
## Purpose
Resolves #2353

## Goals
Add missing guidance on how to mount a shared registry between WSO2 Integrator: MI replicas in a Kubernetes active-active cluster, and clarify which registry directories/scenarios require sharing.

## Approach
Added a new "Registry synchronization" subsection to the Kubernetes Deployment Patterns page, under "Multiple Replicas (with Coordination)". It covers:
1. When registry sharing is actually needed (only if dynamically changing Message Processor/Inbound Endpoint state via the Management API or Integration Control Plane).
2. How to mount a shared registry in Kubernetes specifically - since pods are ephemeral and don't share a local filesystem the way VM nodes do in the existing VM-based instructions (which rely on rsync/NFS-style sync between hosts).
3. A concrete approach using a `ReadWriteMany` (RWX) `PersistentVolumeClaim` mounted at `<MI_HOME>/registry` across all replicas, with a sample volume mount snippet.
4. A tip for environments where RWX volumes aren't supported.

## User stories
As a DevOps engineer deploying WSO2 Integrator: MI on Kubernetes with Message Processors or stateful inbound endpoints, I want clear guidance on how to share the registry across replicas so that artifact state persists correctly when nodes join or leave the cluster.

## Release note
Added documentation on shared registry mounting for WSO2 Integrator: MI clusters deployed on Kubernetes.

## Documentation
`en/docs/install-and-setup/setup/deployment/kubernetes-deployment-patterns.md`

## Training
N/A

## Certification
N/A - Documentation-only update.

## Marketing
N/A

## Automation tests
N/A - No code changes introduced.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Verified the surrounding page structure and cross-referenced the existing VM-based "Registry synchronization" instructions in deploying-wso2-mi.md to ensure conceptual consistency.

## Learning
Researched existing WSO2 MI/EI registry-sharing documentation across versions to understand when sharing is required, then identified that no existing Kubernetes-specific shared-storage guidance exists anywhere in the docs, confirming this as a genuine gap matching the issue description.